### PR TITLE
Add saas-ocm-agent-operator-bundle to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,4 @@ LocalRegistryDockerfile
 # app-sre pipeline testing
 .docker/
 Dockerfile.olm-registry
-saas-managed-upgrade-operator-bundle/
+saas-ocm-agent-operator-bundle/


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The `.gitignore` has a bit of a legacy `managed-upgrade-operator` reference in it concerning ignoring the `saas-managed-upgrade-operator-bundle`. This corrects that to be `saas-ocm-agent-operator-bundle`.

### Which Jira/Github issue(s) this PR fixes?
N/A
