### PR TITLE
[OSD-8943] add ocm-agent liveliness and readiness probes

### DIFF
--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -16,6 +16,14 @@ const (
 	OCMAgentPort = 8080
 	// OCMAgentMetricsPort is the container port number used by the agent for exposing metrics
 	OCMAgentMetricsPort = 8081
+	// OCMAgentLivezPath is the liveliness probe path
+	OCMAgentLivezPath = "/livez"
+	// OCMAgentReadyzPath is the readyness probe path
+	OCMAgentReadyzPath = "/readyz"
+	// 	OCMAgentHealthDelay is the liveliness/readyness probe delay in seconds
+	OCMAgentHealthDelay = 10
+	// 	OCMAgentHealthDelay is the liveliness/readyness check period in seconds
+	OCMAgentHealthPeriod = 5
 	// OCMAgentServiceAccount is the name of the service account that will run the OCM Agent
 	OCMAgentServiceAccount = "ocm-agent"
 	// OCMAgentCommand is the name of the OCM Agent binary to run in the deployment

--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -13,9 +13,9 @@ const (
 	// OCMAgentPortName is the name of the OCM Agent service port used in the OCM Agent Deployment
 	OCMAgentPortName = "ocm-agent"
 	// OCMAgentPort is the container port number used by the agent for exposing its services
-	OCMAgentPort = 8080
+	OCMAgentPort = 8081
 	// OCMAgentMetricsPort is the container port number used by the agent for exposing metrics
-	OCMAgentMetricsPort = 8081
+	OCMAgentMetricsPort = 8888
 	// OCMAgentLivezPath is the liveliness probe path
 	OCMAgentLivezPath = "/livez"
 	// OCMAgentReadyzPath is the readyness probe path

--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -20,10 +20,6 @@ const (
 	OCMAgentLivezPath = "/livez"
 	// OCMAgentReadyzPath is the readyness probe path
 	OCMAgentReadyzPath = "/readyz"
-	// 	OCMAgentHealthDelay is the liveliness/readyness probe delay in seconds
-	OCMAgentHealthDelay = 10
-	// 	OCMAgentHealthDelay is the liveliness/readyness check period in seconds
-	OCMAgentHealthPeriod = 5
 	// OCMAgentServiceAccount is the name of the service account that will run the OCM Agent
 	OCMAgentServiceAccount = "ocm-agent"
 	// OCMAgentCommand is the name of the OCM Agent binary to run in the deployment

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
@@ -27,7 +27,7 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 		mockClient *clientmocks.MockClient
 		mockCtrl   *gomock.Controller
 
-		testOcmAgent ocmagentv1alpha1.OcmAgent
+		testOcmAgent        ocmagentv1alpha1.OcmAgent
 		testOcmAgentHandler ocmAgentHandler
 	)
 
@@ -38,7 +38,7 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-ocm-agent",
 			},
-			Spec:   ocmagentv1alpha1.OcmAgentSpec{
+			Spec: ocmagentv1alpha1.OcmAgentSpec{
 				OcmBaseUrl:     "http://api.example.com",
 				Services:       []string{},
 				OcmAgentImage:  "quay.io/ocm-agent:example",
@@ -70,6 +70,21 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			Expect(deployment.Spec.Template.Spec.Volumes[1].Name).To(Equal(testOcmAgent.Spec.TokenSecret))
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(testOcmAgent.Spec.OcmAgentConfig))
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(testOcmAgent.Spec.TokenSecret))
+
+			// make sure LivenessProbe is part of deployment config and has defned path, port, url scheme and timeouts
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Path).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Scheme).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds).To(BeNumerically(">", 0))
+
+			// make sure ReadinessProbe is part of deployment config and has defned path, port url scheme and timeouts
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Path).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds).To(BeNumerically(">", 0))
+
 		})
 	})
 
@@ -80,7 +95,7 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			testNamespacedName = ocmagenthandler.BuildNamespacedName(ocmagenthandler.OCMAgentName)
 			testDeployment = buildOCMAgentDeployment(testOcmAgent)
 		})
-		
+
 		When("the OCM Agent deployment already exists", func() {
 			When("the deployment differs from what is expected", func() {
 				BeforeEach(func() {
@@ -133,7 +148,7 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			})
 		})
 
-		When("the OCM Agent deployment should be removed", func () {
+		When("the OCM Agent deployment should be removed", func() {
 			When("the deployment is already removed", func() {
 				It("does nothing", func() {
 					notFound := k8serrs.NewNotFound(schema.GroupResource{}, testDeployment.Name)
@@ -163,22 +178,22 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			})
 			It("should detect an image change", func() {
 				testDeployment.Spec.Template.Spec.Containers[0].Image = "something else"
-				changed := deploymentConfigChanged(&testDeployment,&goldenDeployment,testconst.Logger)
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
 				Expect(changed).To(BeTrue())
 			})
 			It("should detect a replica change", func() {
 				replicas := int32(5000)
 				testDeployment.Spec.Replicas = &replicas
-				changed := deploymentConfigChanged(&testDeployment,&goldenDeployment,testconst.Logger)
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
 				Expect(changed).To(BeTrue())
 			})
 			It("should detect a affinity change", func() {
 				testDeployment.Spec.Template.Spec.Affinity = nil
-				changed := deploymentConfigChanged(&testDeployment,&goldenDeployment,testconst.Logger)
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
 				Expect(changed).To(BeTrue())
 			})
 			It("not detect a change if there are no differences", func() {
-				changed := deploymentConfigChanged(&testDeployment,&goldenDeployment,testconst.Logger)
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
 				Expect(changed).To(BeFalse())
 			})
 		})

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
@@ -71,20 +71,15 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(testOcmAgent.Spec.OcmAgentConfig))
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(testOcmAgent.Spec.TokenSecret))
 
-			// make sure LivenessProbe is part of deployment config and has defned path, port, url scheme and timeouts
-			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Path).NotTo(BeEmpty())
-			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
-			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Scheme).NotTo(BeEmpty())
-			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds).To(BeNumerically(">", 0))
-			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds).To(BeNumerically(">", 0))
+			// make sure LivenessProbe is part of deployment config and has defned path, port, url and scheme
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Scheme).NotTo(BeEmpty())
 
-			// make sure ReadinessProbe is part of deployment config and has defned path, port url scheme and timeouts
-			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Path).NotTo(BeEmpty())
-			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
-			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme).NotTo(BeEmpty())
-			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds).To(BeNumerically(">", 0))
-			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds).To(BeNumerically(">", 0))
-
+			// make sure ReadinessProbe is part of deployment config and has defned path, port url and scheme
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme).NotTo(BeEmpty())
 		})
 	})
 
@@ -178,6 +173,26 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			})
 			It("should detect an image change", func() {
 				testDeployment.Spec.Template.Spec.Containers[0].Image = "something else"
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
+				Expect(changed).To(BeTrue())
+			})
+			It("should handle missing readiness probe", func() {
+				testDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
+				Expect(changed).To(BeTrue())
+			})
+			It("should handle missing liveness probe", func() {
+				testDeployment.Spec.Template.Spec.Containers[0].LivenessProbe = nil
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
+				Expect(changed).To(BeTrue())
+			})
+			It("should detect a readiness probe change", func() {
+				testDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet = nil
+				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
+				Expect(changed).To(BeTrue())
+			})
+			It("should detect a liveness probe change", func() {
+				testDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet = nil
 				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
 				Expect(changed).To(BeTrue())
 			})

--- a/pkg/ocmagenthandler/ocmagenthandler_service.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_service.go
@@ -2,8 +2,9 @@ package ocmagenthandler
 
 import (
 	"fmt"
-	"github.com/go-logr/logr"
 	"reflect"
+
+	"github.com/go-logr/logr"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,7 +29,7 @@ func buildOCMAgentService(ocmAgent ocmagentv1alpha1.OcmAgent) corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Selector: labels,
 			Ports: []corev1.ServicePort{{
-				TargetPort: intstr.FromInt(oah.OCMAgentServicePort),
+				TargetPort: intstr.FromInt(oah.OCMAgentPort),
 				Name:       oah.OCMAgentPortName,
 				Port:       oah.OCMAgentServicePort,
 				Protocol:   corev1.ProtocolTCP,
@@ -70,7 +71,7 @@ func (o *ocmAgentHandler) ensureService(ocmAgent ocmagentv1alpha1.OcmAgent) erro
 	} else {
 		// It does exist, check if it is what we expected
 		resource := populationFunc()
-		if serviceConfigChanged(foundResource, &resource, o.Log)  {
+		if serviceConfigChanged(foundResource, &resource, o.Log) {
 			// Specs aren't equal, update and fix.
 			o.Log.Info("An OCMAgent service exists but contains unexpected configuration. Restoring.")
 			foundResource.Spec = *resource.Spec.DeepCopy()


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?

To make ocm-agent-operator restore the liveliness and readiness probes if it is changed/missing from the deployment

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
[OSD-8943](https://issues.redhat.com/browse/OSD-8943)

### Special notes for your reviewer:
This is companion PR for ocm-agent health check as part of [OSD-8943](https://issues.redhat.com/browse/OSD-8943) 

### Pre-checks (if applicable):
- [x] Ran `make test` command locally to validate code changes
- [x] Ran `make lint` command locally to validate code changes

