### PR TITLE
OSD-10044 Add cluster ID to OCM Agent config

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,10 +15,11 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/ocm-agent-operator/pkg/apis"
+	controllerconst "github.com/openshift/ocm-agent-operator/pkg/consts/controller"
 	"github.com/openshift/ocm-agent-operator/pkg/controller"
 	"github.com/openshift/ocm-agent-operator/version"
-	controllerconst "github.com/openshift/ocm-agent-operator/pkg/consts/controller"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -124,6 +125,12 @@ func main() {
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// For ClusterVersion resource
+	if err = configv1.Install(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/20_ocm-agent-operator.ClusterRole.yaml
+++ b/deploy/20_ocm-agent-operator.ClusterRole.yaml
@@ -30,3 +30,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusterversions
+    verbs:
+      - get
+      - list
+      - watch

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/openshift/ocm-agent-operator
 go 1.16
 
 require (
-	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
+	github.com/openshift/api v0.0.0-00010101000000-000000000000
 	github.com/operator-framework/operator-sdk v0.18.2
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,7 @@ github.com/go-openapi/spec v0.17.2/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
+github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -741,6 +742,9 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba h1:aimcu15biJzq4gp0LPsa4cOucfiILIgy/PimUO9ncpc=
+github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba/go.mod h1:izBmoXbUu3z5kUa4FjZhvekTsyzIWiOoaIgJiZBBMQs=
+github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
@@ -1065,6 +1069,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1203,6 +1208,7 @@ golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1294,6 +1300,7 @@ golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
@@ -1468,6 +1475,7 @@ k8s.io/client-go v0.21.1/go.mod h1:/kEw4RgW+3xnBGzvp9IWxKSNA+lXn3A7AuH3gdOAzLs=
 k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269/go.mod h1:V5BD6M4CyaN5m+VthcclXWsVcT1Hu+glwa1bi3MIsyE=
 k8s.io/code-generator v0.18.0/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
 k8s.io/code-generator v0.18.2/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
+k8s.io/code-generator v0.21.1/go.mod h1:hUlps5+9QaTrKx+jiM4rmq7YmH8wPOIko64uZCHDh6Q=
 k8s.io/code-generator v0.22.1/go.mod h1:eV77Y09IopzeXOJzndrDyCI88UBok2h6WxAlBwpxa+o=
 k8s.io/component-base v0.0.0-20190918160511-547f6c5d7090/go.mod h1:933PBGtQFJky3TEwYx4aEPZ4IxqhWh3R6DCmzqIn1hA=
 k8s.io/component-base v0.0.0-20191122220729-2684fb322cb9/go.mod h1:NFuUusy/X4Tk21m21tcNUihnmp4OI7lXU7/xA+rYXkc=

--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -41,6 +41,8 @@ const (
 	OCMAgentConfigServicesKey = "services"
 	// OCMAgentConfigURLKey is the name of the key used for the OCM URL configmap entry
 	OCMAgentConfigURLKey = "ocmBaseURL"
+	// OCMAgentConfigClusterID is the name of the key used for the Cluster ID configmap entry
+	OCMAgentConfigClusterID = "clusterID"
 
 	// PullSecretKey defines the key in the pull secret containing the auth tokens
 	PullSecretKey = ".dockerconfigjson"

--- a/pkg/ocmagenthandler/ocmagenthandler_configmap_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_configmap_test.go
@@ -2,6 +2,7 @@ package ocmagenthandler
 
 import (
 	"context"
+	configv1 "github.com/openshift/api/config/v1"
 	"reflect"
 
 	"github.com/golang/mock/gomock"
@@ -29,6 +30,8 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 
 		testOcmAgent        ocmagentv1alpha1.OcmAgent
 		testOcmAgentHandler ocmAgentHandler
+		testClusterId       string
+		testClusterVersion  configv1.ClusterVersion
 	)
 
 	BeforeEach(func() {
@@ -40,8 +43,8 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 			},
 			Spec: ocmagentv1alpha1.OcmAgentSpec{
 				AgentConfig: ocmagentv1alpha1.AgentConfig{
-					OcmBaseUrl: "http://api.example.com",
-					Services:   []string{},
+					OcmBaseUrl:     "http://api.example.com",
+					Services:       []string{},
 				},
 				OcmAgentImage:  "quay.io/ocm-agent:example",
 				TokenSecret:    "example-secret",
@@ -56,11 +59,21 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 			Log:    testconst.Logger,
 			Ctx:    testconst.Context,
 		}
+		testClusterId = "9345c78b-b6b6-4f42-b242-79bfcc403b0a"
+		testClusterVersion = configv1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "version",
+			},
+			Spec: configv1.ClusterVersionSpec{
+				ClusterID: configv1.ClusterID(testClusterId),
+			},
+		}
+		testClusterVersion = testClusterVersion
 	})
 
 	Context("When building an OCM Agent ConfigMap", func() {
 		It("Sets a correct name", func() {
-			cm := buildOCMAgentConfigMap(testOcmAgent)
+			cm := buildOCMAgentConfigMap(testOcmAgent, testClusterId)
 			Expect(cm.Name).To(Equal(testOcmAgent.Spec.OcmAgentConfig))
 		})
 	})
@@ -70,7 +83,7 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 		var testNamespacedName types.NamespacedName
 		BeforeEach(func() {
 			testNamespacedName = ocmagenthandler.BuildNamespacedName(testOcmAgent.Spec.OcmAgentConfig)
-			testConfigMap = buildOCMAgentConfigMap(testOcmAgent)
+			testConfigMap = buildOCMAgentConfigMap(testOcmAgent, testClusterId)
 		})
 		When("the OCM Agent config already exists", func() {
 			When("the config differs from what is expected", func() {
@@ -78,8 +91,9 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 					testConfigMap.Data = map[string]string{"fake": "fake"}
 				})
 				It("updates the configmap", func() {
-					goldenConfig := buildOCMAgentConfigMap(testOcmAgent)
+					goldenConfig := buildOCMAgentConfigMap(testOcmAgent, testClusterId)
 					gomock.InOrder(
+						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, testClusterVersion),
 						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, testConfigMap),
 						mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
 							func(ctx context.Context, d *corev1.ConfigMap, opts ...client.UpdateOptions) error {
@@ -94,6 +108,7 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 			When("the configmap matches what is expected", func() {
 				It("does not update the configmap", func() {
 					gomock.InOrder(
+						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, testClusterVersion),
 						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, testConfigMap),
 					)
 					err := testOcmAgentHandler.ensureConfigMap(testOcmAgent)
@@ -105,6 +120,7 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 			It("creates the configmap", func() {
 				notFound := k8serrs.NewNotFound(schema.GroupResource{}, testConfigMap.Name)
 				gomock.InOrder(
+					mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, testClusterVersion),
 					mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Return(notFound),
 					mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
 						func(ctx context.Context, d *corev1.ConfigMap, opts ...client.CreateOptions) error {

--- a/pkg/ocmagenthandler/ocmagenthandler_configmap_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_configmap_test.go
@@ -68,7 +68,6 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 				ClusterID: configv1.ClusterID(testClusterId),
 			},
 		}
-		testClusterVersion = testClusterVersion
 	})
 
 	Context("When building an OCM Agent ConfigMap", func() {

--- a/test/deploy/20_ocm-agent-operator.ClusterRole.yaml
+++ b/test/deploy/20_ocm-agent-operator.ClusterRole.yaml
@@ -30,3 +30,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusterversions
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

OCM Agent requires the cluster's cluster ID in order to send Service Logs to OCM. 

Given the cluster ID is always static, and rather than complicate OCM Agent by having it need to look it up itself, it makes more sense for OCM Agent Operator to collect the cluster ID and populate it for OCM Agent as config.

It will arrive to OCM Agent in the form of a `clusterID` ConfigMap key.

A PR for OCM Agent to acknowledge and read the cluster ID as a config item will arrive separately but is not required for this PR to be merged.

### Which Jira/Github issue(s) this PR fixes?

[OSD-10044](https://issues.redhat.com/browse/OSD-10044)

### How to test

Note that this PR requires additional RBAC if you are testing via an image deployed on-cluster and running as the `ocm-agent-oeprator` ServiceAccount, notably this addition to the `ClusterRole`: https://github.com/mrbarge/ocm-agent-operator/blob/8419e0e602771b47df505df797850c58eca4e316/deploy/20_ocm-agent-operator.ClusterRole.yaml#L33

If you are testing locally via kubeadmin, no additional RBAC is required.

To test, simply run the operator and verify that the `ocm-agent-config` ConfigMap contains a `clusterID` key after the operator's successful reconcile.

```bash
$ oc get cm -n openshift-ocm-agent-operator ocm-agent-config -o yaml
```

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

