### PR TITLE
OSD-10226 Pass cluster ID as parameter to OA

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler_deployment.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment.go
@@ -155,13 +155,15 @@ func buildOCMAgentArgs(ocmAgent ocmagentv1alpha1.OcmAgent) []string {
 		oah.OCMAgentConfigServicesKey)
 	configURLPath := filepath.Join(oah.OCMAgentConfigMountPath, ocmAgent.Spec.OcmAgentConfig,
 		oah.OCMAgentConfigURLKey)
-
+	clusterIDPath := filepath.Join(oah.OCMAgentConfigMountPath, ocmAgent.Spec.OcmAgentConfig,
+		oah.OCMAgentConfigClusterID)
 	command := []string{
 		oah.OCMAgentCommand,
 		"serve",
 		fmt.Sprintf("--access-token=@%s", accessTokenPath),
 		fmt.Sprintf("--services=@%s", configServicesPath),
 		fmt.Sprintf("--ocm-url=@%s", configURLPath),
+		fmt.Sprintf("--cluster-id=@%s", clusterIDPath),
 	}
 	return command
 }


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
OCM Agent needs to know the cluster ID; it's currently getting that injected into the ConfigMap used to supply config to the pod; now we need to make the agent aware that it has to read that config.

### Which Jira/Github issue(s) this PR fixes?

[OSD-10226](https://issues.redhat.com/browse/OSD-10226)

### Special notes for your reviewer:

Do not merge until https://github.com/openshift/ocm-agent/pull/14 is reviewed/merged.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

