### PR TITLE
[OSD-9052] add the configmap for trusted ca bundle, and mount it to deployment

### DIFF
--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -66,7 +66,10 @@ const (
 	PullSecretKey = ".dockerconfigjson"
 	// PullSecretAuthTokenKey defines the name of the key in the pull secret containing the auth token
 	PullSecretAuthTokenKey = "cloud.openshift.com"
-
+	// InjectCaBundleIndicator defines the name of the key for the label of trusted CA bundle configmap
+	InjectCaBundleIndicator = "config.openshift.io/inject-trusted-cabundle"
+	// TrustedCaBundleConfigMap defines the name of trusted CA bundle configmap
+	TrustedCaBundleConfigMapName = "trusted-ca-bundle"
 )
 
 var (

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
@@ -54,8 +54,10 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			// This is a little brittle based on the naming conventions used in the testOcmAgent
 			Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(testOcmAgent.Spec.OcmAgentConfig))
 			Expect(deployment.Spec.Template.Spec.Volumes[1].Name).To(Equal(testOcmAgent.Spec.TokenSecret))
+			Expect(deployment.Spec.Template.Spec.Volumes[2].Name).To(Equal(ocmagenthandler.TrustedCaBundleConfigMapName))
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(testOcmAgent.Spec.OcmAgentConfig))
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(testOcmAgent.Spec.TokenSecret))
+			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name).To(Equal(ocmagenthandler.TrustedCaBundleConfigMapName))
 
 			// make sure LivenessProbe is part of deployment config and has defned path, port, url and scheme
 			Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path).NotTo(BeEmpty())
@@ -158,7 +160,7 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 				goldenDeployment = buildOCMAgentDeployment(testOcmAgent)
 			})
 			It("should detect a label change", func() {
-				testDeployment.Labels = map[string]string{"dummy":"value"}
+				testDeployment.Labels = map[string]string{"dummy": "value"}
 				changed := deploymentConfigChanged(&testDeployment, &goldenDeployment, testconst.Logger)
 				Expect(changed).To(BeTrue())
 			})


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?
mount the trusted ca bundle to the ocm-agent pod which can be used for proxy with user-ca

### Which Jira/Github issue(s) this PR fixes?
_Fixes #OSD-9052_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

