### PR TITLE
[OSD-9052] fetch the cluster proxy and set them to the deployment

### DIFF
--- a/deploy/20_ocm-agent-operator.ClusterRole.yaml
+++ b/deploy/20_ocm-agent-operator.ClusterRole.yaml
@@ -38,3 +38,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - proxies
+    verbs:
+      - get
+      - list
+      - watch

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,6 +31,7 @@ $ oc get managednotification -n openshift-ocm-agent-operator
 The [OCMAgent Controller](https://github.com/openshift/ocm-agent-operator/tree/master/pkg/controller/ocmagent/ocmagent_controller.go) is responsible for ensuring the deployment or removal of an OCM Agent based upon the presence of an `OCMAgent` Custom Resource.
 
 An `OcmAgent` deployment consists of:
+
 - A `ServiceAccount` (named `ocm-agent`)
 - A `Role` and `RoleBinding` (both named `ocm-agent`) that defines the OCM Agent's API  permissions.
 - A `Deployment` (named `ocm-agent`) which runs the [ocm-agent](https://quay.io/openshift/ocm-agent)
@@ -50,4 +51,11 @@ The `ConfigMap` contains the following items:
 
 | Key | Description | Example |
 | --- | --- | --- |
-| `serviceURL` | OCM Agent service URI | http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081/alertmanager-receiver |
+| `serviceURL` | OCM Agent service URI | <http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081/alertmanager-receiver> |
+
+### cluster proxy support
+
+The OCM Agent Controller will monitor the cluster proxy setting
+and inject the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment
+variables to the OCM Agent deployment automatically based on the
+values of the proxy/cluster object.

--- a/pkg/consts/controller/controller.go
+++ b/pkg/consts/controller/controller.go
@@ -10,5 +10,4 @@ const (
 
 	// ReconcileOCMAgentFinalizer defines the finalizer to apply to the OCM Agent resource
 	ReconcileOCMAgentFinalizer = "ocmagent.managed.openshift.io"
-
 )

--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -84,6 +84,11 @@ var (
 		Namespace: "openshift-monitoring",
 		Name:      "ocm-agent",
 	}
+
+	ProxyNamespacedName = types.NamespacedName{
+		Namespace: "",
+		Name:      "cluster",
+	}
 )
 
 // BuildNamespacedName returns the name and namespace intended for OCM Agent deployment resources

--- a/test/deploy/20_ocm-agent-operator.ClusterRole.yaml
+++ b/test/deploy/20_ocm-agent-operator.ClusterRole.yaml
@@ -38,3 +38,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - proxies
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Set the env to the ocm agent deployment, so that it can be consumed when the cluster proxy enabled

### Which Jira/Github issue(s) this PR fixes?
_Fixes OSD-9052_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

