### PR TITLE
make the SetStatus more configurible and can be used by ocm-agent

### DIFF
--- a/pkg/apis/ocmagent/v1alpha1/managednotification_types.go
+++ b/pkg/apis/ocmagent/v1alpha1/managednotification_types.go
@@ -230,6 +230,7 @@ func (nrs NotificationRecords) GetNotificationRecord(name string) *NotificationR
 
 // SetNotificationRecord adds or overwrites the supplied notification record
 func (nrs *NotificationRecords) SetNotificationRecord(rec NotificationRecord) {
+	rec.ServiceLogSentCount++
 	for i, n := range *nrs {
 		if n.Name == rec.Name {
 			(*nrs)[i] = rec
@@ -240,12 +241,11 @@ func (nrs *NotificationRecords) SetNotificationRecord(rec NotificationRecord) {
 }
 
 // SetStatus updates the status for a given notification record type
-func (nr *NotificationRecord) SetStatus(nct NotificationConditionType, reason string) error {
-	nr.ServiceLogSentCount++
+func (nr *NotificationRecord) SetStatus(nct NotificationConditionType, reason string, cs corev1.ConditionStatus, t *metav1.Time) error {
 	condition := NotificationCondition{
 		Type:               nct,
-		Status:             corev1.ConditionTrue,
-		LastTransitionTime: &metav1.Time{Time: time.Now()},
+		Status:             cs,
+		LastTransitionTime: t,
 		Reason:             reason,
 	}
 	nr.Conditions.SetCondition(condition)

--- a/pkg/apis/ocmagent/v1alpha1/managednotification_types_test.go
+++ b/pkg/apis/ocmagent/v1alpha1/managednotification_types_test.go
@@ -187,7 +187,9 @@ var _ = Describe("OCMAgent Controller", func() {
 			It("updates the existing record", func() {
 				nrs.SetNotificationRecord(newrecord)
 				nr := nrs.GetNotificationRecord(testNotificationName)
-				Expect(reflect.DeepEqual(*nr, newrecord)).To(BeTrue())
+				Expect(reflect.DeepEqual(nr.Name, newrecord.Name)).To(BeTrue())
+				Expect(reflect.DeepEqual(nr.Conditions, newrecord.Conditions)).To(BeTrue())
+				Expect(nr.ServiceLogSentCount).To(Equal(newrecord.ServiceLogSentCount + 1))
 			})
 		})
 		When("the notification record does not exist", func() {
@@ -197,7 +199,9 @@ var _ = Describe("OCMAgent Controller", func() {
 			It("adds the record", func() {
 				nrs.SetNotificationRecord(newrecord)
 				nr := nrs.GetNotificationRecord(testNotificationName)
-				Expect(reflect.DeepEqual(*nr, newrecord)).To(BeTrue())
+				Expect(reflect.DeepEqual(nr.Name, newrecord.Name)).To(BeTrue())
+				Expect(reflect.DeepEqual(nr.Conditions, newrecord.Conditions)).To(BeTrue())
+				Expect(nr.ServiceLogSentCount).To(Equal(newrecord.ServiceLogSentCount + 1))
 			})
 		})
 	})
@@ -214,28 +218,26 @@ var _ = Describe("OCMAgent Controller", func() {
 				nr.Conditions = []v1alpha1.NotificationCondition{}
 			})
 			It("will create the status", func() {
-				currTime := time.Now()
+				currTime := &metav1.Time{Time: time.Now()}
 				Expect(nr.ServiceLogSentCount).To(Equal(int32(0)))
-				err := nr.SetStatus(v1alpha1.ConditionAlertFiring, "testreason")
+				err := nr.SetStatus(v1alpha1.ConditionAlertFiring, "testreason", corev1.ConditionTrue, currTime)
 				Expect(err).To(BeNil())
 				Expect(nr.Conditions[0].Type).To(Equal(v1alpha1.ConditionAlertFiring))
 				Expect(nr.Name).To(Equal(testNotificationName))
-				Expect(nr.ServiceLogSentCount).To(Equal(int32(1)))
 				Expect(nr.Conditions[0].Reason).To(Equal("testreason"))
-				Expect(nr.Conditions[0].LastTransitionTime.After(currTime)).To(BeTrue())
+				Expect(nr.Conditions[0].LastTransitionTime.Equal(currTime)).To(BeTrue())
 			})
 		})
 		When("the condition already exists", func() {
 			It("will update the status", func() {
-				currTime := time.Now()
+				currTime := &metav1.Time{Time: time.Now()}
 				Expect(nr.ServiceLogSentCount).To(Equal(int32(0)))
-				err := nr.SetStatus(v1alpha1.ConditionAlertFiring, "testreason")
+				err := nr.SetStatus(v1alpha1.ConditionAlertFiring, "testreason", corev1.ConditionTrue, currTime)
 				Expect(err).To(BeNil())
 				Expect(nr.Conditions[0].Type).To(Equal(v1alpha1.ConditionAlertFiring))
 				Expect(nr.Name).To(Equal(testNotificationName))
-				Expect(nr.ServiceLogSentCount).To(Equal(int32(1)))
 				Expect(nr.Conditions[0].Reason).To(Equal("testreason"))
-				Expect(nr.Conditions[0].LastTransitionTime.After(currTime)).To(BeTrue())
+				Expect(nr.Conditions[0].LastTransitionTime.Equal(currTime)).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Update the functions which will be used by ocm-agent to update the notification status.
Dependency of https://github.com/openshift/ocm-agent/pull/22

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-10340_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

