### PR TITLE
Only apply networkpolicy to ocm-agent pods

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
@@ -21,6 +21,9 @@ func buildNetworkPolicy() netv1.NetworkPolicy {
 			Namespace: namespacedName.Namespace,
 		},
 		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": oah.OCMAgentName},
+			},
 			Ingress: []netv1.NetworkPolicyIngressRule{{
 				From: []netv1.NetworkPolicyPeer{{
 					NamespaceSelector: &metav1.LabelSelector{


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
`ocm-agent-operator`'s current NetworkPolicy is too broad, it applies to every pod in the namespace.

Mainly this prevents anything from communicating to the `ocm-agent-operator` registry catalog.

We only need the `ocm-agent` NetworkPolicy to apply to the `ocm-agent` pods themselves, so this sets the PodSelector to do exactly that.
