### PR TITLE
[OSD-10467] Set Resources.Limits and Resources.Requests

### DIFF
--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -70,6 +70,12 @@ const (
 	InjectCaBundleIndicator = "config.openshift.io/inject-trusted-cabundle"
 	// TrustedCaBundleConfigMap defines the name of trusted CA bundle configmap
 	TrustedCaBundleConfigMapName = "trusted-ca-bundle"
+	// ResourceLimitsCPU and ResourceLimitsMemory defines the cpu and memory limits for OA deployment
+	ResourceLimitsCPU    = "0.2"
+	ResourceLimitsMemory = "128Mi"
+	// ResourceRequestsCPU and ResourceRequestsMemory defines the cpu and memory requests for OA deployment
+	ResourceRequestsCPU    = "0.1"
+	ResourceRequestsMemory = "64Mi"
 )
 
 var (

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -108,6 +109,17 @@ func buildOCMAgentDeployment(ocmAgent ocmagentv1alpha1.OcmAgent) appsv1.Deployme
 		return volumeMounts[i].Name < volumeMounts[j].Name
 	})
 
+	// Define resource limits for the config
+	resourceLimits := corev1.ResourceList{
+		corev1.ResourceCPU:    k8sresource.MustParse(oah.ResourceLimitsCPU),
+		corev1.ResourceMemory: k8sresource.MustParse(oah.ResourceLimitsMemory),
+	}
+	// Define resource requests for the config
+	resourceRequests := corev1.ResourceList{
+		corev1.ResourceCPU:    k8sresource.MustParse(oah.ResourceRequestsCPU),
+		corev1.ResourceMemory: k8sresource.MustParse(oah.ResourceRequestsMemory),
+	}
+
 	// Construct the command arguments of the agent
 	ocmAgentCommand := buildOCMAgentArgs(ocmAgent)
 
@@ -173,6 +185,10 @@ func buildOCMAgentDeployment(ocmAgent ocmagentv1alpha1.OcmAgent) appsv1.Deployme
 									Port:   intstr.FromInt(oah.OCMAgentPort),
 								},
 							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits:   resourceLimits,
+							Requests: resourceRequests,
 						},
 					}},
 				},

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
@@ -69,6 +69,17 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path).NotTo(BeEmpty())
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntVal).To(BeNumerically(">", 0))
 			Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme).NotTo(BeEmpty())
+
+			// make sure Resources Limits is part of deployment config and has defined limits for memory and cpu
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(BeNumerically(">", 0))
+
+			// make sure Resources Requests is part of deployment config and has defined limits for memory and cpu
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value()).To(BeNumerically(">", 0))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().Value()).To(BeNumerically(">", 0))
+
 		})
 	})
 


### PR DESCRIPTION
 As we are going to add new web server running in pod on the infra nodes. It has the risk that the service itself have some performance issue, which may cause the memory or cpu usage issue on that node.


### What type of PR is this?
_(feature/refactor)_


### What this PR does / why we need it?

Sets Resources.Limits and Resources.Requests for cpu and memory in ocm-agent deployment config

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-10467](https://issues.redhat.com/browse/OSD-10467)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Ran `make test` command locally to validate code changes

