### PR TITLE
Changing failure message for notification record not found

### DIFF
--- a/pkg/apis/ocmagent/v1alpha1/managednotification_types.go
+++ b/pkg/apis/ocmagent/v1alpha1/managednotification_types.go
@@ -147,7 +147,7 @@ func (m *ManagedNotificationStatus) GetNotificationRecord(n string) (*Notificati
 			return &t, nil
 		}
 	}
-	return nil, fmt.Errorf("notification with name %v not found", n)
+	return nil, fmt.Errorf("notification record with name %v not found", n)
 }
 
 // HasNotificationRecord returns whether or not a notification status history exists

--- a/pkg/apis/ocmagent/v1alpha1/managednotification_types.go
+++ b/pkg/apis/ocmagent/v1alpha1/managednotification_types.go
@@ -147,7 +147,7 @@ func (m *ManagedNotificationStatus) GetNotificationRecord(n string) (*Notificati
 			return &t, nil
 		}
 	}
-	return nil, fmt.Errorf("notification record with name %v not found", n)
+	return nil, fmt.Errorf("notification record for notification %v not found", n)
 }
 
 // HasNotificationRecord returns whether or not a notification status history exists


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
While adding tests, the message was confusing as it searched for notificationrecord but reported notification not found. Small fix in message.


