### PR TITLE
added request/limit resources to ocm-agent operator

### DIFF
--- a/deploy/50_ocm-agent-operator.Deployment.yaml
+++ b/deploy/50_ocm-agent-operator.Deployment.yaml
@@ -30,6 +30,13 @@ spec:
         - name: ocm-agent-operator
           # Replace this with the built image name
           image: REPLACE_IMAGE
+          resources:
+            requests:
+              memory: "40Mi"
+              cpu: "1m"
+            limits:
+              memory: "64Mi"
+              cpu: "4m"
           command:
             - ocm-agent-operator
           imagePullPolicy: Always


### PR DESCRIPTION
### What this PR does / why we need it?
**What**: Set CPU and Memory request and limit values for the ocm-agent-operator deployment.
**Why**: ocm-agent-operator should run with specific resource requests and limits to prevent it from consuming too many resources on cluster nodes.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12762

Pre-checks (if applicable):
- Tested changes against a cluster and updated results and screenshots on JIRA ticket. 

