### PR TITLE
Remove resolvedBody as required defenition in CRD

### DIFF
--- a/api/v1alpha1/managednotification_types.go
+++ b/api/v1alpha1/managednotification_types.go
@@ -294,3 +294,17 @@ func (c *Conditions) SetCondition(new NotificationCondition) {
 	}
 	*c = append(*c, new)
 }
+
+// ShouldSendResolved checks whether OA should send the SL for resolved alert
+func (m ManagedNotification) ShouldSendResolved(n string, firing bool) (bool, error) {
+	// logic for deciding whether a resolved SL should be sent goes here
+	// If no notification exists, one cannot be sent
+	t, err := m.GetNotificationForName(n)
+	if err != nil {
+		return false, err
+	}
+	if firing || len(t.ResolvedDesc) > 0 {
+		return true, nil
+	}
+	return false, nil
+}

--- a/api/v1alpha1/managednotification_types.go
+++ b/api/v1alpha1/managednotification_types.go
@@ -218,6 +218,11 @@ func (m *ManagedNotification) CanBeSent(n string, firing bool) (bool, error) {
 			return false, err
 		}
 
+		// If resolved body is empty, do not send SL for resolved alert
+		if len(t.ResolvedDesc) == 0 {
+			return false, nil
+		}
+
 		// If alert is not firing, only firing status notification can be sent
 		firingStatus := s.Conditions.GetCondition(ConditionAlertFiring).Status
 		if firingStatus != corev1.ConditionTrue {
@@ -293,18 +298,4 @@ func (c *Conditions) SetCondition(new NotificationCondition) {
 		}
 	}
 	*c = append(*c, new)
-}
-
-// ShouldSendResolved checks whether OA should send the SL for resolved alert
-func (m ManagedNotification) ShouldSendResolved(n string, firing bool) (bool, error) {
-	// logic for deciding whether a resolved SL should be sent goes here
-	// If no notification exists, one cannot be sent
-	t, err := m.GetNotificationForName(n)
-	if err != nil {
-		return false, err
-	}
-	if firing || len(t.ResolvedDesc) > 0 {
-		return true, nil
-	}
-	return false, nil
 }

--- a/api/v1alpha1/managednotification_types.go
+++ b/api/v1alpha1/managednotification_types.go
@@ -46,7 +46,7 @@ type Notification struct {
 	ActiveDesc string `json:"activeBody"`
 
 	// The body text of the Service Log notification when the alert is resolved
-	ResolvedDesc string `json:"resolvedBody"`
+	ResolvedDesc string `json:"resolvedBody,omitempty"`
 
 	// +kubebuilder:validation:Enum={"Debug","Info","Warning","Error","Fatal"}
 	// The severity of the Service Log notification
@@ -55,7 +55,6 @@ type Notification struct {
 	// Measured in hours. The minimum time interval that must elapse between active Service Log notifications
 	ResendWait int32 `json:"resendWait"`
 }
-
 
 // ManagedNotificationSpec defines the desired state of ManagedNotification
 type ManagedNotificationSpec struct {
@@ -127,7 +126,7 @@ type ManagedNotification struct {
 	Status ManagedNotificationStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // ManagedNotificationList contains a list of ManagedNotification
 type ManagedNotificationList struct {

--- a/api/v1alpha1/managednotification_types_test.go
+++ b/api/v1alpha1/managednotification_types_test.go
@@ -15,7 +15,8 @@ import (
 var _ = Describe("OCMAgent Controller", func() {
 
 	const (
-		testNotificationName = "test-notification"
+		testNotificationName    = "test-notification"
+		testNotificationNameWrb = "test-notification-wrb"
 	)
 
 	var (
@@ -80,6 +81,44 @@ var _ = Describe("OCMAgent Controller", func() {
 		It("will return the correct notification", func() {
 			t, err := testManagedNotification.GetNotificationForName(testNotificationName)
 			Expect(t.Name).To(Equal(testNotificationName))
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("will return the correct notification if the resolve body is empty", func() {
+			testManagedNotificationWrb := &v1alpha1.ManagedNotification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-wrb",
+					Namespace: "test-ns-wrb",
+				},
+				Spec: v1alpha1.ManagedNotificationSpec{
+					Notifications: []v1alpha1.Notification{
+						{
+							Name:       testNotificationNameWrb,
+							Summary:    "Test Summary",
+							ActiveDesc: "Test Firing",
+							Severity:   "Info",
+							ResendWait: 1,
+						},
+					},
+				},
+				Status: v1alpha1.ManagedNotificationStatus{
+					NotificationRecords: []v1alpha1.NotificationRecord{
+						{
+							Name:                testNotificationName,
+							ServiceLogSentCount: 0,
+							Conditions: []v1alpha1.NotificationCondition{
+								{
+									Type:               v1alpha1.ConditionAlertFiring,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: &metav1.Time{Time: time.Now()},
+									Reason:             "Test reason",
+								},
+							},
+						},
+					},
+				},
+			}
+			t, err := testManagedNotificationWrb.GetNotificationForName(testNotificationNameWrb)
+			Expect(t.Name).To(Equal(testNotificationNameWrb))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/api/v1alpha1/managednotification_types_test.go
+++ b/api/v1alpha1/managednotification_types_test.go
@@ -119,6 +119,7 @@ var _ = Describe("OCMAgent Controller", func() {
 			}
 			t, err := testManagedNotificationWrb.GetNotificationForName(testNotificationNameWrb)
 			Expect(t.Name).To(Equal(testNotificationNameWrb))
+			Expect(t.ResolvedDesc).To(Equal(""))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/api/v1alpha1/managednotification_types_test.go
+++ b/api/v1alpha1/managednotification_types_test.go
@@ -20,7 +20,8 @@ var _ = Describe("OCMAgent Controller", func() {
 	)
 
 	var (
-		testManagedNotification *v1alpha1.ManagedNotification
+		testManagedNotification    *v1alpha1.ManagedNotification
+		testManagedNotificationWrb *v1alpha1.ManagedNotification
 	)
 
 	BeforeEach(func() {
@@ -70,6 +71,39 @@ var _ = Describe("OCMAgent Controller", func() {
 				},
 			},
 		}
+		testManagedNotificationWrb = &v1alpha1.ManagedNotification{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-wrb",
+				Namespace: "test-ns-wrb",
+			},
+			Spec: v1alpha1.ManagedNotificationSpec{
+				Notifications: []v1alpha1.Notification{
+					{
+						Name:       testNotificationNameWrb,
+						Summary:    "Test Summary",
+						ActiveDesc: "Test Firing",
+						Severity:   "Info",
+						ResendWait: 1,
+					},
+				},
+			},
+			Status: v1alpha1.ManagedNotificationStatus{
+				NotificationRecords: []v1alpha1.NotificationRecord{
+					{
+						Name:                testNotificationName,
+						ServiceLogSentCount: 0,
+						Conditions: []v1alpha1.NotificationCondition{
+							{
+								Type:               v1alpha1.ConditionAlertFiring,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: &metav1.Time{Time: time.Now()},
+								Reason:             "Test reason",
+							},
+						},
+					},
+				},
+			},
+		}
 	})
 
 	Context("When retrieving a notification", func() {
@@ -84,39 +118,6 @@ var _ = Describe("OCMAgent Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("will return the correct notification if the resolve body is empty", func() {
-			testManagedNotificationWrb := &v1alpha1.ManagedNotification{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-wrb",
-					Namespace: "test-ns-wrb",
-				},
-				Spec: v1alpha1.ManagedNotificationSpec{
-					Notifications: []v1alpha1.Notification{
-						{
-							Name:       testNotificationNameWrb,
-							Summary:    "Test Summary",
-							ActiveDesc: "Test Firing",
-							Severity:   "Info",
-							ResendWait: 1,
-						},
-					},
-				},
-				Status: v1alpha1.ManagedNotificationStatus{
-					NotificationRecords: []v1alpha1.NotificationRecord{
-						{
-							Name:                testNotificationName,
-							ServiceLogSentCount: 0,
-							Conditions: []v1alpha1.NotificationCondition{
-								{
-									Type:               v1alpha1.ConditionAlertFiring,
-									Status:             corev1.ConditionTrue,
-									LastTransitionTime: &metav1.Time{Time: time.Now()},
-									Reason:             "Test reason",
-								},
-							},
-						},
-					},
-				},
-			}
 			t, err := testManagedNotificationWrb.GetNotificationForName(testNotificationNameWrb)
 			Expect(t.Name).To(Equal(testNotificationNameWrb))
 			Expect(t.ResolvedDesc).To(Equal(""))
@@ -198,6 +199,14 @@ var _ = Describe("OCMAgent Controller", func() {
 			})
 			It("will not send", func() {
 				cansend, err := testManagedNotification.CanBeSent(testNotificationName, false)
+				Expect(cansend).To(BeFalse())
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("the resolved body is empty", func() {
+			It("will not send", func() {
+				cansend, err := testManagedNotificationWrb.CanBeSent(testNotificationNameWrb, false)
 				Expect(cansend).To(BeFalse())
 				Expect(err).To(BeNil())
 			})

--- a/deploy/crds/ocmagent.managed.openshift.io_managednotifications.yaml
+++ b/deploy/crds/ocmagent.managed.openshift.io_managednotifications.yaml
@@ -73,7 +73,6 @@ spec:
                   - activeBody
                   - name
                   - resendWait
-                  - resolvedBody
                   - severity
                   - summary
                   type: object


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
To remove the required definition for `resolvedBody` in managednotification.  
This is the first step to make send resolved service log to be optional

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-13528](https://issues.redhat.com/browse/OSD-13528)

### Special notes for your reviewer:
This change mainly focus on CRD definition

### Pre-checks (if applicable):
- [x] Tested the latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes


