### PR TITLE
Prevent panic when checking MFNR send status

### DIFF
--- a/api/v1alpha1/managedfleetnotificationrecord_types.go
+++ b/api/v1alpha1/managedfleetnotificationrecord_types.go
@@ -157,6 +157,10 @@ func (fnr *ManagedFleetNotificationRecord) CanBeSent(mc, name, clusterID string)
 		return false, err
 	}
 
+	if ri.LastTransitionTime == nil {
+		return true, nil
+	}
+
 	nextSend := ri.LastTransitionTime.Time.Add(time.Duration(interval) * time.Hour)
 
 	if time.Now().After(nextSend) {


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Prevent a panic when checking `CanBeSent` with a FleetNotificationRecord that's never been sent before.

