### PR TITLE
Ensure that API MNFR modifying functions modify the object

### DIFF
--- a/api/v1alpha1/managedfleetnotificationrecord_types_test.go
+++ b/api/v1alpha1/managedfleetnotificationrecord_types_test.go
@@ -1,0 +1,150 @@
+package v1alpha1_test
+
+import (
+	"time"
+
+	"github.com/openshift/ocm-agent-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OCMAgent Controller MFNR Type", func() {
+
+	var (
+		testMNFR *v1alpha1.ManagedFleetNotificationRecord
+	)
+
+	BeforeEach(func() {
+		testMNFR = &v1alpha1.ManagedFleetNotificationRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-mc-id",
+				Namespace: "openshift-ocm-agent-operator",
+			},
+			Status: v1alpha1.ManagedFleetNotificationRecordStatus{
+				ManagementCluster: "test-mc-id",
+				NotificationRecordByName: []v1alpha1.NotificationRecordByName{
+					{
+						NotificationName: "test-notification-1",
+						ResendWait:       1,
+						NotificationRecordItems: []v1alpha1.NotificationRecordItem{
+							{
+								HostedClusterID:     "test-hc-1-1",
+								ServiceLogSentCount: 0,
+								LastTransitionTime:  nil,
+							},
+							{
+								HostedClusterID:     "test-hc-1-2",
+								ServiceLogSentCount: 1,
+								LastTransitionTime:  &metav1.Time{Time: time.Now().Add(time.Duration(-5) * time.Hour)},
+							},
+							{
+								HostedClusterID:     "test-hc-1-3",
+								ServiceLogSentCount: 0,
+								LastTransitionTime:  nil,
+							},
+						},
+					},
+					{
+						NotificationName: "test-notification-2",
+						ResendWait:       24,
+						NotificationRecordItems: []v1alpha1.NotificationRecordItem{
+							{
+								HostedClusterID:     "test-hc-2-1",
+								ServiceLogSentCount: 0,
+								LastTransitionTime:  nil,
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	Context("When updating a notification record item", func() {
+		Context("When the notification record item already exists", func() {
+			It("will update it correctly", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				nri := testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems[1]
+				nri2, err := testMNFR.UpdateNotificationRecordItem(nr.NotificationName, nri.HostedClusterID)
+				Expect(err).To(BeNil())
+				Expect(nri2.ServiceLogSentCount).To(Equal(2))
+				Expect(testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems[1].ServiceLogSentCount).To(Equal(2))
+			})
+		})
+		Context("When the notification does not exist", func() {
+			It("will return an error", func() {
+				_, err := testMNFR.UpdateNotificationRecordItem("nope", "nope")
+				Expect(err).NotTo(BeNil())
+			})
+		})
+		Context("When the notification record item does not exist", func() {
+			It("will return an error", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				_, err := testMNFR.UpdateNotificationRecordItem(nr.NotificationName, "nope")
+				Expect(err).NotTo(BeNil())
+			})
+		})
+	})
+
+	Context("When adding a notification record item", func() {
+		Context("If the notification record item doesn't exists", func() {
+			It("will add the item", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				nfi, err := testMNFR.AddNotificationRecordItem("test-hc-1-4", &nr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems)).To(Equal(4))
+				Expect(nfi.HostedClusterID).To(Equal("test-hc-1-4"))
+			})
+		})
+		Context("If the notification record item already exists", func() {
+			It("will error", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				nfi, err := testMNFR.AddNotificationRecordItem("test-hc-1-3", &nr)
+				Expect(err).To(HaveOccurred())
+				Expect(nfi).To(BeNil())
+			})
+		})
+		Context("If the notification record doesn't exist", func() {
+			It("will error", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				// intentionally bork the notification record name - this won't change the MNFR
+				nr.NotificationName = "wont-find-this"
+				nfi, err := testMNFR.AddNotificationRecordItem("test-hc-1-3", &nr)
+				Expect(err).To(HaveOccurred())
+				Expect(nfi).To(BeNil())
+			})
+		})
+	})
+
+	Context("When removing a notification record item", func() {
+		Context("When the notification record item already exists", func() {
+			It("will update it correctly", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				nri := testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems[1]
+				nr2, err := testMNFR.RemoveNotificationRecordItem(nr.NotificationName, nri.HostedClusterID)
+				Expect(err).To(BeNil())
+				Expect(len(testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems)).To(Equal(2))
+				Expect(testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems[0].HostedClusterID).To(Equal("test-hc-1-1"))
+				Expect(testMNFR.Status.NotificationRecordByName[0].NotificationRecordItems[1].HostedClusterID).To(Equal("test-hc-1-3"))
+				Expect(nr2.NotificationRecordItems[0].HostedClusterID).To(Equal("test-hc-1-1"))
+				Expect(nr2.NotificationRecordItems[1].HostedClusterID).To(Equal("test-hc-1-3"))
+			})
+		})
+		Context("When the notification does not exist", func() {
+			It("will return an error", func() {
+				_, err := testMNFR.RemoveNotificationRecordItem("nope", "nope")
+				Expect(err).NotTo(BeNil())
+			})
+		})
+		Context("When the notification record item does not exist", func() {
+			It("will return an error", func() {
+				nr := testMNFR.Status.NotificationRecordByName[0]
+				_, err := testMNFR.RemoveNotificationRecordItem(nr.NotificationName, "nope")
+				Expect(err).NotTo(BeNil())
+			})
+		})
+	})
+
+})

--- a/controllers/fleetnotification/fleetnotification_controller_suite_test.go
+++ b/controllers/fleetnotification/fleetnotification_controller_suite_test.go
@@ -1,77 +1,13 @@
-/*
-Copyright 2022.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package fleetnotification
+package fleetnotification_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-
-func TestAPIs(t *testing.T) {
+func TestOCMAgent(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+	RunSpecs(t, "OCMAgent FleetNotification Controller Suite")
 }
-
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-}, 60)
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
- Ensures that the object mutating functions for the `ManagedFleetNotificationRecord` type actually modify the object for which the functions are being called.
- Adds unit tests to verify correctness of operation.

