### PR TITLE
Fixing bug for wrongful deletion of fleet mode secrets

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/ocmagenthandler/ocmagenthandler.go
@@ -86,9 +86,12 @@ func (o *ocmAgentHandler) EnsureOCMAgentResourcesAbsent(ocmAgent ocmagentv1alpha
 		o.ensureDeploymentDeleted,
 		o.ensureServiceDeleted,
 		o.ensureAllConfigMapsDeleted,
-		o.ensureAccessTokenSecretDeleted,
 		o.ensureNetworkPolicyDeleted,
 		o.ensureServiceMonitorDeleted,
+	}
+
+	if !ocmAgent.Spec.FleetMode {
+		ensureFuncs = append(ensureFuncs, o.ensureAccessTokenSecretDeleted)
 	}
 
 	for _, fn := range ensureFuncs {


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
In fleetmode working of ocm-agent-operator, the secrets required for fleet mode are not created by OAO so shouldn't be deleted by it as well. However, when an instance of `OCMAgent` is deleted that's setup in fleet mode, the associated fleetmode secret is deleted as well. This fix will prevent the fleetmode secrets from being deleted.

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [OSD-15390](https://issues.redhat.com/browse/OSD-15390)

### Special notes for your reviewer:
This bug is was noticed as an extension to the testing work done in [OSD-15390](https://issues.redhat.com/browse/OSD-15390) while adding support for multiple instances of `OCMAgent` and testing it.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

