### PR TITLE
Ensure tokenSecret value is used for the env var

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler_deployment.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment.go
@@ -100,7 +100,7 @@ func buildOCMAgentDeployment(ocmAgent ocmagentv1alpha1.OcmAgent) appsv1.Deployme
 		{Name: "HTTP_PROXY"},
 		{Name: "HTTPS_PROXY"},
 		{Name: "NO_PROXY"},
-		{Name: "OCM_AGENT_SECRET_NAME", Value: ocmAgent.Name},
+		{Name: "OCM_AGENT_SECRET_NAME", Value: ocmAgent.Spec.TokenSecret},
 		{Name: "OCM_AGENT_CONFIGMAP_NAME", Value: ocmAgent.Name + ocmagenthandler.ConfigMapSuffix},
 	}
 
@@ -412,7 +412,7 @@ func (o *ocmAgentHandler) buildEnvVars(ocmAgent ocmagentv1alpha1.OcmAgent) ([]co
 	envVars = append(envVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: proxyStatus.HTTPProxy})
 	envVars = append(envVars, corev1.EnvVar{Name: "HTTPS_PROXY", Value: proxyStatus.HTTPSProxy})
 	envVars = append(envVars, corev1.EnvVar{Name: "NO_PROXY", Value: proxyStatus.NoProxy})
-	envVars = append(envVars, corev1.EnvVar{Name: "OCM_AGENT_SECRET_NAME", Value: ocmAgent.Name})
+	envVars = append(envVars, corev1.EnvVar{Name: "OCM_AGENT_SECRET_NAME", Value: ocmAgent.Spec.TokenSecret})
 	envVars = append(envVars, corev1.EnvVar{Name: "OCM_AGENT_CONFIGMAP_NAME", Value: ocmAgent.Name + ocmagenthandler.ConfigMapSuffix})
 
 	return envVars, nil


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Use the `tokenSecret` value from the `ocmgent` CR as the value used in the `OCM_AGENT_SECRET_NAME` environment variable (instead of the CR name). Otherwise, if a `tokenSecret` value is used which does not match the CR name, the wrong path will be looked up by OCM Agent.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

