### PR TITLE
Set network policy specific for OAO fleet mode

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
@@ -25,7 +25,7 @@ func buildNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent) netv1.NetworkPolicy 
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "name",
 				Operator: "In",
-				Values:   []string{"observatorium-*"},
+				Values:   []string{"observatorium-mst-production"},
 			}},
 		}
 	} else {


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The networkpolicy wildcard for fleet mode OAO is not working. Setting it to be the specific namespace to allow.

