### PR TITLE
Add openshift-monitoring to fleet-mode networkpolicy

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
@@ -25,7 +25,7 @@ func buildNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent) netv1.NetworkPolicy 
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "name",
 				Operator: "In",
-				Values:   []string{"observatorium-mst-production"},
+				Values:   []string{"observatorium-mst-production","openshift-monitoring"},
 			}},
 		}
 	} else {


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The fleet mode OCM Agent's networkpolicy needs to allow the `openshift-monitoring` namespace ingress in order for its metrics to be crawled successfully.

