### PR TITLE
Generalising networkpolicy name with OCMAgent name and mode suffix

### DIFF
--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -12,9 +12,9 @@ const (
 	// OCMAgentNamespace is the fall-back namespace to use for OCM Agent Deployments
 	OCMAgentNamespace = "openshift-ocm-agent-operator"
 	// OCMAgentNetworkPolicyName is the name of the network policy to restrict OCM Agent access
-	OCMAgentNetworkPolicyName = "ocm-agent-allow-only-alertmanager"
+	OCMAgentNetworkPolicySuffix = "-allow-only-alertmanager"
 	// OCMFleetAgentNetworkPolicyName is the name of the network policy to restrict OA for HS
-	OCMFleetAgentNetworkPolicyName = "ocm-agent-allow-rhobs-alertmanager"
+	OCMFleetAgentNetworkPolicySuffix = "-allow-rhobs-alertmanager"
 	// OCMAgentPortName is the name of the OCM Agent service port used in the OCM Agent Deployment
 	OCMAgentPortName = "ocm-agent"
 	// OCMAgentPort is the container port number used by the agent for exposing its services

--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
@@ -2,8 +2,9 @@ package ocmagenthandler
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/types"
 	"reflect"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	netv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,16 +21,16 @@ func buildNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent) netv1.NetworkPolicy 
 		namespaceSelector *metav1.LabelSelector
 	)
 	if ocmAgent.Spec.FleetMode {
-		namespacedName = oah.BuildNamespacedName(oah.OCMFleetAgentNetworkPolicyName)
+		namespacedName = oah.BuildNamespacedName(ocmAgent.Name + oah.OCMFleetAgentNetworkPolicySuffix)
 		namespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
 				Key:      "name",
 				Operator: "In",
-				Values:   []string{"observatorium-mst-production","openshift-monitoring"},
+				Values:   []string{"observatorium-mst-production", "openshift-monitoring"},
 			}},
 		}
 	} else {
-		namespacedName = oah.BuildNamespacedName(oah.OCMAgentNetworkPolicyName)
+		namespacedName = oah.BuildNamespacedName(ocmAgent.Name + oah.OCMAgentNetworkPolicySuffix)
 		namespaceSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{"name": "openshift-monitoring"},
 		}
@@ -61,9 +62,9 @@ func buildNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent) netv1.NetworkPolicy 
 func (o *ocmAgentHandler) ensureNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent) error {
 	var namespacedName types.NamespacedName
 	if ocmAgent.Spec.FleetMode {
-		namespacedName = oah.BuildNamespacedName(oah.OCMFleetAgentNetworkPolicyName)
+		namespacedName = oah.BuildNamespacedName(ocmAgent.Name + oah.OCMFleetAgentNetworkPolicySuffix)
 	} else {
-		namespacedName = oah.BuildNamespacedName(oah.OCMAgentNetworkPolicyName)
+		namespacedName = oah.BuildNamespacedName(ocmAgent.Name + oah.OCMAgentNetworkPolicySuffix)
 	}
 	foundResource := &netv1.NetworkPolicy{}
 	populationFunc := func() netv1.NetworkPolicy {
@@ -108,9 +109,9 @@ func (o *ocmAgentHandler) ensureNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent
 func (o *ocmAgentHandler) ensureNetworkPolicyDeleted(ocmAgent ocmagentv1alpha1.OcmAgent) error {
 	var namespacedName types.NamespacedName
 	if ocmAgent.Spec.FleetMode {
-		namespacedName = oah.BuildNamespacedName(oah.OCMFleetAgentNetworkPolicyName)
+		namespacedName = oah.BuildNamespacedName(ocmAgent.Name + oah.OCMFleetAgentNetworkPolicySuffix)
 	} else {
-		namespacedName = oah.BuildNamespacedName(oah.OCMAgentNetworkPolicyName)
+		namespacedName = oah.BuildNamespacedName(ocmAgent.Name + oah.OCMAgentNetworkPolicySuffix)
 	}
 	foundResource := &netv1.NetworkPolicy{}
 	// Does the resource already exist?

--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy_test.go
@@ -52,9 +52,9 @@ var _ = Describe("OCM Agent NetworkPolicy Handler", func() {
 			nph = buildNetworkPolicy(testHSOcmAgent)
 		})
 		It("Has the expected name and namespace", func() {
-			Expect(np.Name).To(Equal(oah.OCMAgentNetworkPolicyName))
+			Expect(np.Name).To(Equal(testOcmAgent.Name + oah.OCMAgentNetworkPolicySuffix))
 			Expect(np.Namespace).To(Equal(oah.OCMAgentNamespace))
-			Expect(nph.Name).To(Equal(oah.OCMFleetAgentNetworkPolicyName))
+			Expect(nph.Name).To(Equal(testHSOcmAgent.Name + oah.OCMFleetAgentNetworkPolicySuffix))
 			Expect(nph.Namespace).To(Equal(oah.OCMAgentNamespace))
 		})
 	})


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

This PR fixes the bug where multiple instances of OCMAgent for the same mode (default mode or fleet mode) didn't have unique NetworkPolicy resource so far. This PR generalises the name of the networkpolicy such that it starts with the name of the `OCMAgent` resource associated to it and has a suffix based on the mode in which the OCMAgent instance is supposed to operate in.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-15926](https://issues.redhat.com/browse/OSD-15926)

### Special notes for your reviewer:
- Ran `curl` for two OCMAgent pods in default mode (each having its unique NetworkPolicy) from `openshift-monitoring` namespace and it worked fine. It failed for both pods when running `curl` from different namespace.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes


