### PR TITLE
[AUTH-388] set pod security admission labels for namespace

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -45,6 +45,9 @@ objects:
             name: openshift-ocm-agent-operator
             labels:
               openshift.io/cluster-monitoring: "true"
+              pod-security.kubernetes.io/enforce: 'baseline'
+              pod-security.kubernetes.io/audit: 'baseline'
+              pod-security.kubernetes.io/warn: 'baseline'
         - apiVersion: operators.coreos.com/v1alpha1
           kind: CatalogSource
           metadata:

--- a/test/deploy/01_openshift-ocm-agent-operator.Namespace.yaml
+++ b/test/deploy/01_openshift-ocm-agent-operator.Namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: test-ocm-agent-operator
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This sets pod security admission labels. Currently, none are set and starting with OpenShift 4.13 this generates warnings in Telemetry. This fixes it.

Refer to https://kubernetes.io/docs/concepts/security/pod-security-standards/ to further tighten the labels potentially to the recommended `restricted` level.

The labels were determined by using the https://github.com/stlaz/psachecker tool.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

