### PR TITLE
[OSD-19745] - Make OCM Agent Highly Available

### DIFF
--- a/controllers/ocmagent/ocmagent_controller.go
+++ b/controllers/ocmagent/ocmagent_controller.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
 	ctrlconst "github.com/openshift/ocm-agent-operator/pkg/consts/controller"
@@ -138,5 +139,6 @@ func (r *OcmAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&monitorv1.ServiceMonitor{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Complete(r)
 }

--- a/deploy/20_ocm-agent-operator.Role.yaml
+++ b/deploy/20_ocm-agent-operator.Role.yaml
@@ -4,61 +4,73 @@ metadata:
   name: ocm-agent-operator
   namespace: openshift-ocm-agent-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - services/finalizers
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/finalizers
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ocmagent.managed.openshift.io
-  - ocmagent.managed.openshift.io/finalizers
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  - networkpolicies/finalizers
-  verbs:
-  - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/finalizers
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ocmagent.managed.openshift.io
+      - ocmagent.managed.openshift.io/finalizers
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - networkpolicies/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - "policy"
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -73,6 +73,8 @@ const (
 	ResourceRequestsMemory = "30Mi"
 	// ConfigMapSuffix is the suffix added to configmap name to always make it unique compared to secret name
 	ConfigMapSuffix = "-cm"
+	// PDBSuffix is the suffix added to PDB name to always make it unique
+	PDBSuffix = "-pdb"
 )
 
 var (

--- a/pkg/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/ocmagenthandler/ocmagenthandler.go
@@ -69,6 +69,7 @@ func (o *ocmAgentHandler) EnsureOCMAgentResourcesExist(ocmAgent ocmagentv1alpha1
 		o.ensureService,
 		o.ensureAllNetworkPolicies,
 		o.ensureServiceMonitor,
+		o.ensurePodDisruptionBudget,
 	}
 	for _, fn := range ensureFuncs {
 		err := fn(ocmAgent)
@@ -88,6 +89,7 @@ func (o *ocmAgentHandler) EnsureOCMAgentResourcesAbsent(ocmAgent ocmagentv1alpha
 		o.ensureAllConfigMapsDeleted,
 		o.ensureAllNetworkPoliciesDeleted,
 		o.ensureServiceMonitorDeleted,
+		o.ensurePodDisruptionBudgetDeleted,
 	}
 
 	if !ocmAgent.Spec.FleetMode {

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment.go
@@ -155,6 +155,21 @@ func buildOCMAgentDeployment(ocmAgent ocmagentv1alpha1.OcmAgent) appsv1.Deployme
 								Weight: 1,
 							}},
 						},
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app": "ocm-agent",
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
 					},
 					Tolerations: []corev1.Toleration{{
 						Operator: corev1.TolerationOpExists,

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment_test.go
@@ -82,6 +82,16 @@ var _ = Describe("OCM Agent Deployment Handler", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value()).To(BeNumerically(">", 0))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().Value()).To(BeNumerically(">", 0))
 
+			// Validate Pod Anti-Affinity
+			Expect(deployment.Spec.Template.Spec.Affinity).NotTo(BeNil())
+			Expect(deployment.Spec.Template.Spec.Affinity.PodAntiAffinity).NotTo(BeNil())
+			Expect(deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).NotTo(BeEmpty())
+
+			podAntiAffinity := deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+			Expect(podAntiAffinity.Weight).To(Equal(int32(100)))
+			Expect(podAntiAffinity.PodAffinityTerm.TopologyKey).To(Equal("kubernetes.io/hostname"))
+			Expect(podAntiAffinity.PodAffinityTerm.LabelSelector.MatchLabels).To(HaveKeyWithValue("app", "ocm-agent"))
+
 		})
 	})
 

--- a/pkg/ocmagenthandler/ocmagenthandler_pdb.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_pdb.go
@@ -1,0 +1,93 @@
+package ocmagenthandler
+
+import (
+	"context"
+	"reflect"
+
+	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
+	oah "github.com/openshift/ocm-agent-operator/pkg/consts/ocmagenthandler"
+	v1 "k8s.io/api/policy/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func buildOCMAgentPodDisruptionBudget(ocmAgent ocmagentv1alpha1.OcmAgent) *v1.PodDisruptionBudget {
+	namespacedName := oah.BuildNamespacedName(ocmAgent.Name + oah.PDBSuffix)
+
+	return &v1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespacedName.Name,
+			Namespace: namespacedName.Namespace,
+		},
+		Spec: v1.PodDisruptionBudgetSpec{
+			MinAvailable: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 1,
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "ocm-agent",
+				},
+			},
+		},
+	}
+}
+
+// ensurePodDisruptionBudget ensures that an OCMAgent PDB exists on the cluster
+// and that its configuration matches what is expected.
+func (o *ocmAgentHandler) ensurePodDisruptionBudget(ocmAgent ocmagentv1alpha1.OcmAgent) error {
+	pdb := buildOCMAgentPodDisruptionBudget(ocmAgent)
+	foundPDB := &v1.PodDisruptionBudget{}
+
+	// Check if the PDB already exists
+	if err := o.Client.Get(context.TODO(), types.NamespacedName{
+		Name: pdb.Name, Namespace: pdb.Namespace}, foundPDB); err != nil {
+
+		if k8serrors.IsNotFound(err) {
+			o.Log.Info("A Pod Disruption Budget does not exist; will be created", "PDB.Namespace", pdb.Namespace, "PDB.Name", pdb.Name)
+			// Set the controller reference
+			if err := controllerutil.SetControllerReference(&ocmAgent, pdb, o.Scheme); err != nil {
+				return err
+			}
+			// and create it now
+			err = o.Client.Create(context.TODO(), pdb)
+
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	} else {
+		if !reflect.DeepEqual(foundPDB.Spec.MinAvailable, pdb.Spec.MinAvailable) {
+			foundPDB.Spec = *pdb.Spec.DeepCopy()
+			o.Log.Info("Updating Pod Disruption Budget", "PDB.Namespace", foundPDB.Namespace, "PDB.Name", foundPDB.Name)
+			err = o.Client.Update(context.TODO(), foundPDB)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ensurePodDisruptionBudgetDeleted removes the PDB from the cluster
+func (o *ocmAgentHandler) ensurePodDisruptionBudgetDeleted(ocmAgent ocmagentv1alpha1.OcmAgent) error {
+	pdb := buildOCMAgentPodDisruptionBudget(ocmAgent)
+	foundPDB := &v1.PodDisruptionBudget{}
+
+	if err := o.Client.Get(context.TODO(), types.NamespacedName{
+		Name: pdb.Name, Namespace: pdb.Namespace}, foundPDB); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	o.Log.Info("Ensuring Pod Disruption Budget is removed", "PDB.Namespace", foundPDB.Namespace, "PDB.Name", foundPDB.Name)
+	return o.Client.Delete(context.TODO(), foundPDB)
+}

--- a/pkg/ocmagenthandler/ocmagenthandler_pdb_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_pdb_test.go
@@ -1,0 +1,99 @@
+package ocmagenthandler
+
+import (
+	"context"
+
+	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
+	oah "github.com/openshift/ocm-agent-operator/pkg/consts/ocmagenthandler"
+	testconst "github.com/openshift/ocm-agent-operator/pkg/consts/test/init"
+	clientmocks "github.com/openshift/ocm-agent-operator/pkg/util/test/generated/mocks/client"
+	v1 "k8s.io/api/policy/v1"
+	k8serrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("OCM Agent Pod Disruption Budget Handler", func() {
+	var (
+		mockClient *clientmocks.MockClient
+		mockCtrl   *gomock.Controller
+
+		testOcmAgent        ocmagentv1alpha1.OcmAgent
+		testOcmAgentHandler ocmAgentHandler
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = clientmocks.NewMockClient(mockCtrl)
+		testOcmAgent = testconst.TestOCMAgent
+		testOcmAgentHandler = ocmAgentHandler{
+			Client: mockClient,
+			Log:    testconst.Logger,
+			Ctx:    testconst.Context,
+			Scheme: testconst.Scheme,
+		}
+	})
+
+	Context("Managing the OCM Agent Pod Disruption Budget", func() {
+		var testPDB v1.PodDisruptionBudget
+		var testNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			testNamespacedName = oah.BuildNamespacedName(testOcmAgent.Name + "-pdb")
+			testPDB = *buildOCMAgentPodDisruptionBudget(testOcmAgent)
+		})
+
+		It("creates the PDB if it does not exist", func() {
+			notFound := k8serrs.NewNotFound(schema.GroupResource{}, "")
+			mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Return(notFound)
+			mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, pdb *v1.PodDisruptionBudget, opts ...client.CreateOptions) error {
+					Expect(pdb.Name).To(Equal(testPDB.Name))
+					Expect(pdb.Namespace).To(Equal(testPDB.Namespace))
+					Expect(pdb.Spec).To(Equal(testPDB.Spec))
+					return nil
+				},
+			)
+			err := testOcmAgentHandler.ensurePodDisruptionBudget(testOcmAgent)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("updates the PDB if it exists but differs from the expected", func() {
+			differentPDB := testPDB
+			differentPDB.Spec.MinAvailable = &intstr.IntOrString{IntVal: 2}
+			mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, differentPDB)
+			mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, pdb *v1.PodDisruptionBudget, opts ...client.UpdateOptions) error {
+					Expect(pdb.Spec).To(Equal(buildOCMAgentPodDisruptionBudget(testOcmAgent).Spec))
+					return nil
+				},
+			)
+			err := testOcmAgentHandler.ensurePodDisruptionBudget(testOcmAgent)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("deletes the PDB if it exists", func() {
+			mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, testPDB)
+			mockClient.EXPECT().Delete(gomock.Any(), &testPDB).Return(nil)
+			err := testOcmAgentHandler.ensurePodDisruptionBudgetDeleted(testOcmAgent)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does nothing if the PDB is already removed", func() {
+			notFound := k8serrs.NewNotFound(schema.GroupResource{}, testPDB.Name)
+			mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Return(notFound)
+			err := testOcmAgentHandler.ensurePodDisruptionBudgetDeleted(testOcmAgent)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+})


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Update the OCM agent deployment configuration to tolerate disruptions, such as infra nodes being terminated to make OCM Agent Highly Available

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-19745

### Test Steps in a staging cluster:
https://gitlab.cee.redhat.com/-/snippets/7462
