### PR TITLE
prevent pdb create/delete if replicas count set to <=1

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/ocmagenthandler/ocmagenthandler.go
@@ -69,8 +69,11 @@ func (o *ocmAgentHandler) EnsureOCMAgentResourcesExist(ocmAgent ocmagentv1alpha1
 		o.ensureService,
 		o.ensureAllNetworkPolicies,
 		o.ensureServiceMonitor,
-		o.ensurePodDisruptionBudget,
 	}
+	if ocmAgent.Spec.Replicas > 1 {
+		ensureFuncs = append(ensureFuncs, o.ensurePodDisruptionBudget)
+	}
+
 	for _, fn := range ensureFuncs {
 		err := fn(ocmAgent)
 		if err != nil {


### PR DESCRIPTION
### What type of PR is this?
Add logic to create/delete pdb only if the `ocm-agent` service replicas count is set to > 1. 
