### PR TITLE
Fix(OSD-20956): nilptr deref when cleaning up managedfleetrecorditems with an empty LastTransitionTimestamp

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 
 ENV USER_UID=1001 \
     USER_NAME=ocm-agent-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
nil ptr deref when a `managedfleetnotificationrecorditem` has an empty last transition. 

This is currently the case on the rhobs production cluster because it never sends SLs/LS to integration clusters, but also handles the alerts. This results in the last transition timestamp for the integration items to be nil.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-20956

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

