### PR TITLE
[OSD-21689] update networkpolicy for ocm-agent fleet mode on management cluster

### DIFF
--- a/pkg/consts/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/consts/ocmagenthandler/ocmagenthandler.go
@@ -4,17 +4,22 @@ import (
 	"fmt"
 	"net/url"
 
-	ns "github.com/openshift/ocm-agent-operator/pkg/util/namespace"
 	"k8s.io/apimachinery/pkg/types"
+
+	ns "github.com/openshift/ocm-agent-operator/pkg/util/namespace"
 )
 
 const (
 	// OCMAgentNamespace is the fall-back namespace to use for OCM Agent Deployments
 	OCMAgentNamespace = "openshift-ocm-agent-operator"
-	// OCMAgentNetworkPolicyName is the name of the network policy to restrict OCM Agent access
-	OCMAgentNetworkPolicySuffix = "-allow-only-alertmanager"
-	// OCMFleetAgentNetworkPolicyName is the name of the network policy to restrict OA for HS
-	OCMFleetAgentNetworkPolicySuffix = "-allow-rhobs-alertmanager"
+	// OCMAgentDefaultNetworkPolicySuffix is the name of the network policy to restrict OCM Agent access
+	OCMAgentDefaultNetworkPolicySuffix = "-allow-only-alertmanager"
+	// OCMAgentRHOBSNetworkPolicySuffix is the name of the network policy to restrict OA for rhobs
+	OCMAgentRHOBSNetworkPolicySuffix = "-allow-rhobs-alertmanager"
+	// OCMAgentOBONetworkPolicySuffix is the name of the network policy to restrict OA for obo
+	OCMAgentOBONetworkPolicySuffix = "-allow-obo-alertmanager"
+	// OCMAgentMUONetworkPolicySuffix is the name of the network policy to restrict OA for MUO
+	OCMAgentMUONetworkPolicySuffix = "-allow-muo-communication"
 	// OCMAgentPortName is the name of the OCM Agent service port used in the OCM Agent Deployment
 	OCMAgentPortName = "ocm-agent"
 	// OCMAgentPort is the container port number used by the agent for exposing its services
@@ -74,7 +79,11 @@ const (
 	// ConfigMapSuffix is the suffix added to configmap name to always make it unique compared to secret name
 	ConfigMapSuffix = "-cm"
 	// PDBSuffix is the suffix added to PDB name to always make it unique
-	PDBSuffix = "-pdb"
+	PDBSuffix          = "-pdb"
+	NamespaceMonitorng = "openshift-monitoring"
+	NamespaceMUO       = "openshift-managed-upgrade-operator"
+	NamespaceRHOBS     = "observatorium-mst-production"
+	NamespaceOBO       = "openshift-observability-operator"
 )
 
 var (

--- a/pkg/ocmagenthandler/ocmagenthandler.go
+++ b/pkg/ocmagenthandler/ocmagenthandler.go
@@ -6,9 +6,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/go-logr/logr"
-	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
 )
 
 //go:generate mockgen -source $GOFILE -destination ../../pkg/util/test/generated/mocks/$GOPACKAGE/interfaces.go -package mocks

--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy_test.go
@@ -2,24 +2,24 @@ package ocmagenthandler
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
+	"go.uber.org/mock/gomock"
 	k8serrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"go.uber.org/mock/gomock"
 
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
 	oah "github.com/openshift/ocm-agent-operator/pkg/consts/ocmagenthandler"
 	testconst "github.com/openshift/ocm-agent-operator/pkg/consts/test/init"
 	clientmocks "github.com/openshift/ocm-agent-operator/pkg/util/test/generated/mocks/client"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("OCM Agent NetworkPolicy Handler", func() {
@@ -28,15 +28,17 @@ var _ = Describe("OCM Agent NetworkPolicy Handler", func() {
 		mockCtrl   *gomock.Controller
 
 		testOcmAgent        ocmagentv1alpha1.OcmAgent
+		testFleetOcmAgent   ocmagentv1alpha1.OcmAgent
 		testOcmAgentHandler ocmAgentHandler
-		testHSOcmAgent      ocmagentv1alpha1.OcmAgent
+		testNamespace       string
+		networkPolicy       netv1.NetworkPolicy
 	)
 
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockClient = clientmocks.NewMockClient(mockCtrl)
 		testOcmAgent = testconst.TestOCMAgent
-		testHSOcmAgent = testconst.TestHSOCMAgent
+		testFleetOcmAgent = testconst.TestHSOCMAgent
 		testOcmAgentHandler = ocmAgentHandler{
 			Client: mockClient,
 			Log:    testconst.Logger,
@@ -45,167 +47,64 @@ var _ = Describe("OCM Agent NetworkPolicy Handler", func() {
 		}
 	})
 
-	Context("When building an OCM Agent NetworkPolicy for MUO", func() {
-		var muoNetworkPolicy netv1.NetworkPolicy
-
+	Context("When building an OCM Agent NetworkPolicy", func() {
 		BeforeEach(func() {
-			muoNetworkPolicy = buildNetworkPolicyForMUO(testOcmAgent)
+			testNamespace = oah.NamespaceMonitorng
+			networkPolicy = buildNetworkPolicy(testOcmAgent, testNamespace)
 		})
 
-		It("Should have the expected name and namespace for MUO", func() {
-			Expect(muoNetworkPolicy.Name).To(Equal(testOcmAgent.Name + "-allow-muo-communication"))
-			Expect(muoNetworkPolicy.Namespace).To(Equal(oah.OCMAgentNamespace))
+		It("Should have the expected name, namespace and labels", func() {
+			Expect(networkPolicy.Name).To(ContainSubstring(oah.OCMAgentDefaultNetworkPolicySuffix))
+			Expect(networkPolicy.Namespace).To(Equal(oah.OCMAgentNamespace))
+			Expect(networkPolicy.Labels["app"]).To(Equal(testOcmAgent.Name))
 		})
 
-		It("Should include an ingress rule to allow traffic from the MUO namespace", func() {
-			Expect(len(muoNetworkPolicy.Spec.Ingress)).To(Equal(1))
-			Expect(muoNetworkPolicy.Spec.Ingress[0].From).To(HaveLen(1))
+		It("Should include an ingress rule to allow traffic from the specified namespace", func() {
+			Expect(len(networkPolicy.Spec.Ingress)).To(Equal(1))
+			Expect(networkPolicy.Spec.Ingress[0].From).To(HaveLen(1))
 
-			nsSelector := muoNetworkPolicy.Spec.Ingress[0].From[0].NamespaceSelector
+			nsSelector := networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector
 			Expect(nsSelector).NotTo(BeNil())
-			Expect(nsSelector.MatchLabels).To(HaveKeyWithValue("kubernetes.io/metadata.name", "openshift-managed-upgrade-operator"))
+			Expect(nsSelector.MatchLabels).To(HaveKeyWithValue("kubernetes.io/metadata.name", testNamespace))
 		})
 
 		It("Should apply to pods with the correct app label", func() {
-			Expect(muoNetworkPolicy.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app", testOcmAgent.Name))
+			Expect(networkPolicy.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app", testOcmAgent.Name))
 		})
-	})
-
-	Context("Managing the OCM Agent NetworkPolicy for MUO", func() {
-		var testMUONetworkPolicy netv1.NetworkPolicy
-		var testMUONamespacedName types.NamespacedName
-
-		BeforeEach(func() {
-			testMUONetworkPolicy = buildNetworkPolicyForMUO(testOcmAgent)
-			testMUONamespacedName = types.NamespacedName{
-				Namespace: testMUONetworkPolicy.Namespace,
-				Name:      testMUONetworkPolicy.Name,
-			}
-		})
-
-		When("the MUO network policy does not already exist", func() {
-			It("creates the MUO network policy", func() {
-				notFound := k8serrs.NewNotFound(schema.GroupResource{}, testMUONetworkPolicy.Name)
-				gomock.InOrder(
-					mockClient.EXPECT().Get(gomock.Any(), testMUONamespacedName, gomock.Any()).Return(notFound),
-					mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
-						func(ctx context.Context, d *netv1.NetworkPolicy, opts ...client.CreateOptions) error {
-							Expect(reflect.DeepEqual(d.Spec, testMUONetworkPolicy.Spec)).To(BeTrue())
-							return nil
-						}),
-				)
-				err := testOcmAgentHandler.ensureNetworkPolicyForMUO(testOcmAgent)
-				Expect(err).To(BeNil())
-			})
-		})
-
-		When("the MUO network policy already exists", func() {
-			When("the MUO network policy differs from what is expected", func() {
-				BeforeEach(func() {
-					testMUONetworkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"fake": "fake"}
-				})
-				It("updates the MUO network policy", func() {
-					gomock.InOrder(
-						mockClient.EXPECT().Get(gomock.Any(), testMUONamespacedName, gomock.Any()).SetArg(2, testMUONetworkPolicy),
-						mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, d *netv1.NetworkPolicy, opts ...client.UpdateOptions) error {
-								Expect(reflect.DeepEqual(d.Spec, buildNetworkPolicyForMUO(testOcmAgent).Spec)).To(BeTrue())
-								return nil
-							}),
-					)
-					err := testOcmAgentHandler.ensureNetworkPolicyForMUO(testOcmAgent)
-					Expect(err).To(BeNil())
-				})
-			})
-			When("the MUO network policy matches what is expected", func() {
-				It("does not update the MUO network policy", func() {
-					gomock.InOrder(
-						mockClient.EXPECT().Get(gomock.Any(), testMUONamespacedName, gomock.Any()).SetArg(2, testMUONetworkPolicy),
-					)
-					err := testOcmAgentHandler.ensureNetworkPolicyForMUO(testOcmAgent)
-					Expect(err).To(BeNil())
-				})
-			})
-		})
-	})
-
-	Context("When building an OCM Agent NetworkPolicy", func() {
-		var np, nph netv1.NetworkPolicy
-		BeforeEach(func() {
-			np = buildNetworkPolicy(testOcmAgent)
-			nph = buildNetworkPolicy(testHSOcmAgent)
-		})
-
-		It("Has the expected name and namespace", func() {
-			Expect(np.Name).To(Equal(testOcmAgent.Name + oah.OCMAgentNetworkPolicySuffix))
-			Expect(np.Namespace).To(Equal(oah.OCMAgentNamespace))
-			Expect(nph.Name).To(Equal(testHSOcmAgent.Name + oah.OCMFleetAgentNetworkPolicySuffix))
-			Expect(nph.Namespace).To(Equal(oah.OCMAgentNamespace))
-		})
-
 	})
 
 	Context("Managing the OCM Agent NetworkPolicy", func() {
-		var testNetworkPolicy, testHSNetworkPolicy netv1.NetworkPolicy
-		var testNamespacedName, testHSNamespacedName types.NamespacedName
+		var testNamespacedName types.NamespacedName
 		BeforeEach(func() {
-			testNetworkPolicy = buildNetworkPolicy(testOcmAgent)
-			testNamespacedName = types.NamespacedName{
-				Namespace: testNetworkPolicy.Namespace,
-				Name:      testNetworkPolicy.Name,
-			}
-			testHSNetworkPolicy = buildNetworkPolicy(testHSOcmAgent)
-			testHSNamespacedName = types.NamespacedName{
-				Namespace: testHSNetworkPolicy.Namespace,
-				Name:      testHSNetworkPolicy.Name,
-			}
+			testNamespace = oah.NamespaceOBO
+			testNamespacedName = buildNetworkPolicyName(testOcmAgent, testNamespace)
+			networkPolicy = buildNetworkPolicy(testOcmAgent, testNamespace)
 		})
 		When("the network policy already exists", func() {
 			When("the network policy differs from what is expected", func() {
 				BeforeEach(func() {
-					testNetworkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"fake": "fake"}
-					testHSNetworkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"fake": "fake"}
+					networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"fake": "fake"}
 				})
 				It("updates the networkpolicy", func() {
-					goldenNetworkPolicy := buildNetworkPolicy(testOcmAgent)
+					goldenNetworkPolicy := buildNetworkPolicy(testOcmAgent, testNamespace)
 					gomock.InOrder(
-						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, testNetworkPolicy),
+						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, networkPolicy),
 						mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
 							func(ctx context.Context, d *netv1.NetworkPolicy, opts ...client.UpdateOptions) error {
 								Expect(reflect.DeepEqual(d.Spec, goldenNetworkPolicy.Spec)).To(BeTrue())
 								return nil
 							}),
 					)
-					err := testOcmAgentHandler.ensureNetworkPolicy(testOcmAgent)
-					Expect(err).To(BeNil())
-				})
-				It("updates the fleet OA networkpolicy", func() {
-					goldenNetworkPolicy := buildNetworkPolicy(testHSOcmAgent)
-					gomock.InOrder(
-						mockClient.EXPECT().Get(gomock.Any(), testHSNamespacedName, gomock.Any()).SetArg(2, testHSNetworkPolicy),
-						mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, d *netv1.NetworkPolicy, opts ...client.UpdateOptions) error {
-								Expect(reflect.DeepEqual(d.Spec, goldenNetworkPolicy.Spec)).To(BeTrue())
-								return nil
-							}),
-					)
-					err := testOcmAgentHandler.ensureNetworkPolicy(testHSOcmAgent)
+					err := testOcmAgentHandler.ensureNetworkPolicy(testOcmAgent, testNamespace)
 					Expect(err).To(BeNil())
 				})
 			})
 			When("the networkpolicy matches what is expected", func() {
 				It("does not update the networkpolicy", func() {
 					gomock.InOrder(
-						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, testNetworkPolicy),
+						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, networkPolicy),
 					)
-					err := testOcmAgentHandler.ensureNetworkPolicy(testOcmAgent)
-					Expect(err).To(BeNil())
-				})
-				It("does not update the networkpolicy for HS", func() {
-					gomock.InOrder(
-						mockClient.EXPECT().Get(gomock.Any(), testHSNamespacedName, gomock.Any()).SetArg(2, testHSNetworkPolicy),
-					)
-					err := testOcmAgentHandler.ensureNetworkPolicy(testHSOcmAgent)
+					err := testOcmAgentHandler.ensureNetworkPolicy(testOcmAgent, testNamespace)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -213,35 +112,64 @@ var _ = Describe("OCM Agent NetworkPolicy Handler", func() {
 
 		When("the OCM Agent networkpolicy does not already exist", func() {
 			It("creates the networkpolicy", func() {
-				notFound := k8serrs.NewNotFound(schema.GroupResource{}, testNetworkPolicy.Name)
+				notFound := k8serrs.NewNotFound(schema.GroupResource{}, networkPolicy.Name)
 				gomock.InOrder(
 					mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Return(notFound),
 					mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
 						func(ctx context.Context, d *netv1.NetworkPolicy, opts ...client.CreateOptions) error {
-							Expect(reflect.DeepEqual(d.Spec, testNetworkPolicy.Spec)).To(BeTrue())
+							Expect(reflect.DeepEqual(d.Spec, networkPolicy.Spec)).To(BeTrue())
 							Expect(d.ObjectMeta.OwnerReferences[0].Kind).To(Equal("OcmAgent"))
 							Expect(*d.ObjectMeta.OwnerReferences[0].BlockOwnerDeletion).To(BeTrue())
 							Expect(*d.ObjectMeta.OwnerReferences[0].Controller).To(BeTrue())
 							return nil
 						}),
 				)
-				err := testOcmAgentHandler.ensureNetworkPolicy(testOcmAgent)
+				err := testOcmAgentHandler.ensureNetworkPolicy(testOcmAgent, testNamespace)
 				Expect(err).To(BeNil())
 			})
-			It("creates the networkpolicy for HS", func() {
-				notFound := k8serrs.NewNotFound(schema.GroupResource{}, testHSNetworkPolicy.Name)
-				gomock.InOrder(
-					mockClient.EXPECT().Get(gomock.Any(), testHSNamespacedName, gomock.Any()).Return(notFound),
-					mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
-						func(ctx context.Context, d *netv1.NetworkPolicy, opts ...client.CreateOptions) error {
-							Expect(reflect.DeepEqual(d.Spec, testHSNetworkPolicy.Spec)).To(BeTrue())
-							Expect(d.ObjectMeta.OwnerReferences[0].Kind).To(Equal("OcmAgent"))
-							Expect(*d.ObjectMeta.OwnerReferences[0].BlockOwnerDeletion).To(BeTrue())
-							Expect(*d.ObjectMeta.OwnerReferences[0].Controller).To(BeTrue())
-							return nil
-						}),
-				)
-				err := testOcmAgentHandler.ensureNetworkPolicy(testHSOcmAgent)
+		})
+	})
+
+	Context("Deleting the ocm agent networkpolicies", func() {
+		var testNamespacedName types.NamespacedName
+		BeforeEach(func() {
+			testNamespace = oah.NamespaceMUO
+			testNamespacedName = buildNetworkPolicyName(testOcmAgent, testNamespace)
+		})
+		When("network policy exists", func() {
+			It("should be able to delete the networkpolicy", func() {
+				networkPolicy = buildNetworkPolicy(testOcmAgent, testNamespace)
+				fmt.Println(networkPolicy)
+				mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).SetArg(2, networkPolicy)
+				mockClient.EXPECT().Delete(gomock.Any(), gomock.Any())
+				err := testOcmAgentHandler.ensureNetworkPolicyDeleted(testOcmAgent, testNamespace)
+				Expect(err).To(BeNil())
+			})
+		})
+		When("network policy does not exist", func() {
+			It("should skip the deletion", func() {
+				notFound := k8serrs.NewNotFound(schema.GroupResource{}, networkPolicy.Name)
+				mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Return(notFound)
+				err := testOcmAgentHandler.ensureNetworkPolicyDeleted(testOcmAgent, testNamespace)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Context("ensure all the required networkpolicies created", func() {
+		When("creating a non-fleet ocm-agent", func() {
+			It("should have the 2 networkpolicies created", func() {
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+				mockClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(2)
+				err := testOcmAgentHandler.ensureAllNetworkPolicies(testOcmAgent)
+				Expect(err).To(BeNil())
+			})
+		})
+		When("creating a fleet ocm-agent", func() {
+			It("should have the 3 networkpolicies created", func() {
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+				mockClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+				err := testOcmAgentHandler.ensureAllNetworkPolicies(testFleetOcmAgent)
 				Expect(err).To(BeNil())
 			})
 		})


### PR DESCRIPTION
### What type of PR is this?
_(feature)_


### What this PR does / why we need it?
To move the ocm-agent-fleet to management cluster, the webhookreceiver will need to receive the alert from the alertmanager which is running in the openshift-observability-operator namespace

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

