### PR TITLE
[OSD-22774] - Enhance the ensurePDB logic to compare the full PDB Spec

### DIFF
--- a/pkg/ocmagenthandler/ocmagenthandler_pdb.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_pdb.go
@@ -52,17 +52,12 @@ func (o *ocmAgentHandler) ensurePodDisruptionBudget(ocmAgent ocmagentv1alpha1.Oc
 			if err := controllerutil.SetControllerReference(&ocmAgent, pdb, o.Scheme); err != nil {
 				return err
 			}
-			// and create it now
-			err = o.Client.Create(context.TODO(), pdb)
-
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
+			// Create it now
+			return o.Client.Create(context.TODO(), pdb)
 		}
+		return err
 	} else {
-		if !reflect.DeepEqual(foundPDB.Spec.MinAvailable, pdb.Spec.MinAvailable) {
+		if !reflect.DeepEqual(foundPDB.Spec, pdb.Spec) {
 			foundPDB.Spec = *pdb.Spec.DeepCopy()
 			o.Log.Info("Updating Pod Disruption Budget", "PDB.Namespace", foundPDB.Namespace, "PDB.Name", foundPDB.Name)
 			err = o.Client.Update(context.TODO(), foundPDB)
@@ -71,7 +66,6 @@ func (o *ocmAgentHandler) ensurePodDisruptionBudget(ocmAgent ocmagentv1alpha1.Oc
 			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Enhance the ensurePDB logic to compare the full PDB Spec"

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-22774

### For reviewers

1. Updated logic has been coverred by test cases
![image](https://github.com/openshift/ocm-agent-operator/assets/5784943/b1ad15a1-805c-45dc-aadb-a9d1efc8910e)
2. Built an OAO image based on this updated PR and tested to run the OAO on my staging `shawn-rosa-dev`
3. Updated the matchLabel field of `app: ocm-agent` to `app: ocm-agent-test` in PDB spec
```
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  creationTimestamp: "2024-05-15T09:55:06Z"
  generation: 3
  name: ocm-agent-pdb
  namespace: openshift-ocm-agent-operator
  ownerReferences:
  - apiVersion: ocmagent.managed.openshift.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: OcmAgent
    name: ocm-agent
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app: ocm-agent-test
```
4. Checked the OAO logs
```
oc logs ocm-agent-operator-79c5b6f6df-25v99 -n openshift-ocm-agent-operator

ts=2024-05-16T03:09:10.323718676Z level=info logger=handler.OCMAgent msg="Updating Pod Disruption Budget" PDB.Namespace=openshift-ocm-agent-operator PDB.Name=ocm-agent-pdb
ts=2024-05-16T03:09:10.327660651Z level=info logger=controller_ocmagent msg="Successfully setup OCMAgent resources."
ts=2024-05-16T03:09:10.327721222Z level=info logger=controller_ocmagent msg="Reconciling OCMAgent" Request.Namespace=openshift-ocm-agent-operator Request.Name=ocm-agent
```
The logs show that the OAO detected the change in `MatchLabel` section of the `ocm-agent-pdb` (it used not able to detect the fully PDB spec but only the `minAvailable` section) and triggered a reconciliation process and the the `app: ocm-agent` label reverted as outcome.

P.S [More context](https://redhat-internal.slack.com/archives/C01JJKHC0CF/p1714295479017699?thread_ts=1714187850.143879&cid=C01JJKHC0CF)