### PR TITLE
Replace severity levels with supported ones.

### DIFF
--- a/api/v1alpha1/managednotification_types.go
+++ b/api/v1alpha1/managednotification_types.go
@@ -27,11 +27,11 @@ import (
 type NotificationSeverity string
 
 const (
-	SeverityDebug   NotificationSeverity = "Debug"
-	SeverityWarning NotificationSeverity = "Warning"
-	SeverityInfo    NotificationSeverity = "Info"
-	SeverityError   NotificationSeverity = "Error"
-	SeverityFatal   NotificationSeverity = "Fatal"
+	SeverityDebug    NotificationSeverity = "Debug"
+	SeverityWarning  NotificationSeverity = "Warning"
+	SeverityInfo     NotificationSeverity = "Info"
+	SeverityMajor    NotificationSeverity = "Major"
+	SeverityCritical NotificationSeverity = "Critical"
 )
 
 // +kubebuilder:validation:Pattern=`^https?:\/\/.+$`


### PR DESCRIPTION
The Error and Fatal levels were deprecated and no longer work: see https://gitlab.cee.redhat.com/service/ocm-service-log#severity-levels

### What type of PR is this?

Bug

### What this PR does / why we need it?

The current ocm-agent-operator version is breaking cluster-syncs across our hives: https://issues.redhat.com/browse/OHSS-36862 

### Which Jira/Github issue(s) this PR fixes?

Fixes #[OHSS-36862](https://issues.redhat.com//browse/OHSS-36862)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

