### PR TITLE
[SREP-3991] Migrating from OLM to PKO as part of our Konflux CI/CD adoption.

### DIFF
--- a/.tekton/ocm-agent-operator-pko-pull-request.yaml
+++ b/.tekton/ocm-agent-operator-pko-pull-request.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/ocm-agent-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'true'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+  labels:
+    appstudio.openshift.io/application: ocm-agent-operator
+    appstudio.openshift.io/component: ocm-agent-operator-pko
+    pipelines.appstudio.openshift.io/type: build
+  name: ocm-agent-operator-pko-on-pull-request
+  namespace: ocm-agent-operator-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocm-agent-operator-tenant/openshift/ocm-agent-operator-pko:on-pr-{{revision}}
+  - name: dockerfile
+    value: build/Dockerfile.pko
+  - name: path-context
+    value: deploy_pko
+  - name: skip-preflight-cert-check
+    value: true
+  - name: image-expires-after
+    value: 3d
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ocm-agent-operator-pko
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/openshift/boilerplate
+    - name: revision
+      value: master
+    - name: pathInRepo
+      value: pipelines/docker-build-oci-ta/pipeline.yaml
+status: {}

--- a/.tekton/ocm-agent-operator-pko-push.yaml
+++ b/.tekton/ocm-agent-operator-pko-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/ocm-agent-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'false'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+  labels:
+    appstudio.openshift.io/application: ocm-agent-operator
+    appstudio.openshift.io/component: ocm-agent-operator-pko
+    pipelines.appstudio.openshift.io/type: build
+  name: ocm-agent-operator-pko-on-push
+  namespace: ocm-agent-operator-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocm-agent-operator-tenant/openshift/ocm-agent-operator-pko:{{revision}}
+  - name: dockerfile
+    value: build/Dockerfile.pko
+  - name: path-context
+    value: deploy_pko
+  - name: skip-preflight-cert-check
+    value: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ocm-agent-operator-pko
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/openshift/boilerplate
+    - name: revision
+      value: master
+    - name: pathInRepo
+      value: pipelines/docker-build-oci-ta/pipeline.yaml
+status: {}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
 
 ENV USER_UID=1001 \
     USER_NAME=ocm-agent-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/build/Dockerfile.pko
+++ b/build/Dockerfile.pko
@@ -1,0 +1,13 @@
+FROM scratch
+
+LABEL com.redhat.component="openshift-ocm-agent-operator" \
+      io.k8s.description="ocm-agent-operator Operator for OpenShift Dedicated" \
+      description="ocm-agent-operator Operator for OpenShift Dedicated" \
+      distribution-scope="public" \
+      name="openshift/ocm-agent-operator" \
+      url="https://github.com/openshift/ocm-agent-operator" \
+      vendor="Red Hat, Inc." \
+      release="v0.0.0" \
+      version="v0.0.0"
+
+COPY * /package/

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -1,0 +1,97 @@
+---
+# This Job cleans up old OLM resources after migrating to PKO
+# IMPORTANT: Review and customize this template before deploying!
+# 
+# Things to customize:
+# 1. Adjust the namespace if needed
+# 2. Modify resource filters (CSV names, labels, etc.)
+# 3. Review RBAC permissions
+# 4. Update the cleanup logic for your specific operator
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: openshift-ocm-agent-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              # CUSTOMIZE: Update the label selector for your operator
+              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
+              oc -n openshift-ocm-agent-operator delete csv -l "operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator" || true
+              
+              # CUSTOMIZE: Add any additional cleanup logic here
+              # Examples:
+              # - Delete subscriptions
+              # - Delete operator groups
+              # - Clean up custom resources
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/ClusterRole-ocm-agent-operator.yaml
+++ b/deploy_pko/ClusterRole-ocm-agent-operator.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ocmagent.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/ClusterRoleBinding-ocm-agent-operator.yaml
+++ b/deploy_pko/ClusterRoleBinding-ocm-agent-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator
+roleRef:
+  kind: ClusterRole
+  name: ocm-agent-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/CustomResourceDefinition-managedfleetnotificationrecords.ocmagent.managed.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-managedfleetnotificationrecords.ocmagent.managed.openshift.io.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: managedfleetnotificationrecords.ocmagent.managed.openshift.io
+spec:
+  group: ocmagent.managed.openshift.io
+  names:
+    kind: ManagedFleetNotificationRecord
+    listKind: ManagedFleetNotificationRecordList
+    plural: managedfleetnotificationrecords
+    shortNames:
+    - mfnr
+    singular: managedfleetnotificationrecord
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedFleetNotificationRecord is the Schema for the managedfleetnotificationrecords
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: ManagedFleetNotificationRecordStatus defines the observed
+              state of ManagedFleetNotificationRecord
+            properties:
+              managementCluster:
+                description: Managed Fleet Notification name
+                type: string
+              notificationRecordByName:
+                description: An array structure to record the history for each hosted
+                  cluster
+                items:
+                  description: NotificationRecordByName groups the notification record
+                    item by notification name
+                  properties:
+                    notificationName:
+                      description: Name of the notification
+                      type: string
+                    notificationRecordItems:
+                      description: Notification record item with the notification
+                        name
+                      items:
+                        description: NotificationRecordItem defines the basic structure
+                          of a notification record
+                        properties:
+                          firingNotificationSentCount:
+                            description: FiringNotificationSentCount records the number
+                              of notifications sent for the alert status firing
+                            type: integer
+                          hostedClusterID:
+                            description: The uuid for the hosted cluster per entry
+                            type: string
+                          lastTransitionTime:
+                            description: The last notification sent timestamp
+                            format: date-time
+                            type: string
+                          resolvedNotificationSentCount:
+                            description: ResolvedNotificationSentCount records the
+                              number of notifications sent for the alert status resolving
+                            type: integer
+                        required:
+                        - firingNotificationSentCount
+                        - hostedClusterID
+                        - resolvedNotificationSentCount
+                        type: object
+                      type: array
+                    resendWait:
+                      description: Resend interval for the notification
+                      format: int32
+                      type: integer
+                  required:
+                  - notificationName
+                  - notificationRecordItems
+                  - resendWait
+                  type: object
+                type: array
+            required:
+            - managementCluster
+            - notificationRecordByName
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/CustomResourceDefinition-managedfleetnotifications.ocmagent.managed.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-managedfleetnotifications.ocmagent.managed.openshift.io.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: managedfleetnotifications.ocmagent.managed.openshift.io
+spec:
+  group: ocmagent.managed.openshift.io
+  names:
+    kind: ManagedFleetNotification
+    listKind: ManagedFleetNotificationList
+    plural: managedfleetnotifications
+    shortNames:
+    - mfn
+    singular: managedfleetnotification
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedFleetNotification is the Schema for the managedfleetnotifications
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              fleetNotification:
+                description: FleetNotification defines the desired spec of ManagedFleetNotification
+                properties:
+                  limitedSupport:
+                    description: Whether or not limited support should be sent for
+                      this notification
+                    type: boolean
+                  logType:
+                    description: LogType is a categorization property that can be
+                      used to group service logs for aggregation and managing notification
+                      preferences.
+                    type: string
+                  name:
+                    description: The name of the notification used to associate with
+                      an alert
+                    type: string
+                  notificationMessage:
+                    description: The body text of the notification when the alert
+                      is active
+                    type: string
+                  references:
+                    description: References useful for context or remediation - this
+                      could be links to documentation, KB articles, etc
+                    items:
+                      pattern: ^https?:\/\/.+$
+                      type: string
+                    type: array
+                  resendWait:
+                    description: Measured in hours. The minimum time interval that
+                      must elapse between active notifications
+                    format: int32
+                    type: integer
+                  severity:
+                    description: Re-use the severity definitation in managednotification_types
+                    enum:
+                    - Debug
+                    - Info
+                    - Warning
+                    - Error
+                    - Fatal
+                    type: string
+                  summary:
+                    description: The summary line of the notification
+                    type: string
+                required:
+                - name
+                - notificationMessage
+                - resendWait
+                - severity
+                - summary
+                type: object
+            required:
+            - fleetNotification
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/CustomResourceDefinition-managednotifications.ocmagent.managed.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-managednotifications.ocmagent.managed.openshift.io.yaml
@@ -1,0 +1,162 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: managednotifications.ocmagent.managed.openshift.io
+spec:
+  group: ocmagent.managed.openshift.io
+  names:
+    kind: ManagedNotification
+    listKind: ManagedNotificationList
+    plural: managednotifications
+    singular: managednotification
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedNotification is the Schema for the managednotifications
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedNotificationSpec defines the desired state of ManagedNotification
+            properties:
+              notifications:
+                description: AgentConfig refers to OCM agent config fields separated
+                items:
+                  properties:
+                    activeBody:
+                      description: The body text of the Service Log notification when
+                        the alert is active
+                      type: string
+                    logType:
+                      description: LogType is a categorization property that can be
+                        used to group service logs for aggregation and managing notification
+                        preferences.
+                      type: string
+                    name:
+                      description: The name of the notification used to associate
+                        with an alert
+                      type: string
+                    references:
+                      description: References useful for context or remediation -
+                        this could be links to documentation, KB articles, etc
+                      items:
+                        pattern: ^https?:\/\/.+$
+                        type: string
+                      type: array
+                    resendWait:
+                      description: Measured in hours. The minimum time interval that
+                        must elapse between active Service Log notifications
+                      format: int32
+                      type: integer
+                    resolvedBody:
+                      description: The body text of the Service Log notification when
+                        the alert is resolved
+                      type: string
+                    severity:
+                      description: The severity of the Service Log notification
+                      enum:
+                      - Debug
+                      - Info
+                      - Warning
+                      - Major
+                      - Critical
+                      - Error
+                      - Fatal
+                      type: string
+                    summary:
+                      description: The summary line of the Service Log notification
+                      type: string
+                  required:
+                  - activeBody
+                  - name
+                  - resendWait
+                  - severity
+                  - summary
+                  type: object
+                type: array
+            required:
+            - notifications
+            type: object
+          status:
+            description: ManagedNotificationStatus defines the observed state of ManagedNotification
+            properties:
+              notificationRecords:
+                items:
+                  properties:
+                    conditions:
+                      description: Conditions is a set of Condition instances.
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transit from one
+                              status to another.
+                            format: date-time
+                            type: string
+                          reason:
+                            description: (brief) reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of condition, one of True, False,
+                              Unknown
+                            type: string
+                          type:
+                            description: Type of Notification condition
+                            enum:
+                            - AlertFiring
+                            - AlertResolved
+                            - ServiceLogSent
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      description: Name of the notification
+                      type: string
+                    serviceLogSentCount:
+                      description: ServiceLogSentCount records the number of service
+                        logs sent for the notification
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/CustomResourceDefinition-ocmagents.ocmagent.managed.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-ocmagents.ocmagent.managed.openshift.io.yaml
@@ -1,0 +1,109 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: ocmagents.ocmagent.managed.openshift.io
+spec:
+  group: ocmagent.managed.openshift.io
+  names:
+    kind: OcmAgent
+    listKind: OcmAgentList
+    plural: ocmagents
+    singular: ocmagent
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OcmAgent is the Schema for the ocmagents API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OcmAgentSpec defines the desired state of OcmAgent
+            properties:
+              agentConfig:
+                description: AgentConfig refers to OCM agent config fields separated
+                properties:
+                  ocmBaseUrl:
+                    description: OcmBaseUrl defines the OCM api endpoint for OCM agent
+                      to access
+                    type: string
+                  services:
+                    description: Services defines the supported OCM services, eg,
+                      service_log, cluster_management
+                    items:
+                      type: string
+                    type: array
+                required:
+                - ocmBaseUrl
+                - services
+                type: object
+              fleetMode:
+                description: FleetMode indicates if the OCM agent is running in fleet
+                  mode, default to false
+                type: boolean
+              ocmAgentImage:
+                description: OcmAgentImage defines the image which will be used by
+                  the OCM Agent
+                type: string
+              replicas:
+                description: Replicas defines the replica count for the OCM Agent
+                  service
+                format: int32
+                type: integer
+              tokenSecret:
+                description: TokenSecret points to the secret name which stores the
+                  access token to OCM server
+                type: string
+            required:
+            - agentConfig
+            - ocmAgentImage
+            - replicas
+            - tokenSecret
+            type: object
+          status:
+            description: OcmAgentStatus defines the observed state of OcmAgent
+            properties:
+              availableReplicas:
+                format: int32
+                type: integer
+              serviceStatus:
+                description: ServiceStatus indicates the status of OCM Agent service
+                type: string
+            required:
+            - availableReplicas
+            - serviceStatus
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ocm-agent-operator
+  template:
+    metadata:
+      labels:
+        name: ocm-agent-operator
+        app: ocm-agent-operator
+    spec:
+      serviceAccountName: ocm-agent-operator
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+      containers:
+      - name: ocm-agent-operator
+        image: '{{ .config.image }}'
+        resources:
+          requests:
+            memory: 40Mi
+            cpu: 1m
+          limits:
+            memory: 64Mi
+            cpu: 10m
+        command:
+        - ocm-agent-operator
+        imagePullPolicy: Always
+        env:
+        - name: WATCH_NAMESPACE
+          value: openshift-ocm-agent-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPERATOR_NAME
+          value: ocm-agent-operator

--- a/deploy_pko/Role-ocm-agent-operator.yaml
+++ b/deploy_pko/Role-ocm-agent-operator.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - services/finalizers
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/finalizers
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ocmagent.managed.openshift.io
+  - ocmagent.managed.openshift.io/finalizers
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  - networkpolicies/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy_pko/Role-ocm-agent.yaml
+++ b/deploy_pko/Role-ocm-agent.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocm-agent
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - services/finalizers
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ocmagent.managed.openshift.io
+  resources:
+  - managednotifications
+  - managednotifications/status
+  - managedfleetnotifications
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ocmagent.managed.openshift.io
+  resources:
+  - managedfleetnotificationrecords
+  - managedfleetnotificationrecords/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create

--- a/deploy_pko/Role-prometheus-k8s.yaml
+++ b/deploy_pko/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/RoleBinding-ocm-agent-operator.yaml
+++ b/deploy_pko/RoleBinding-ocm-agent-operator.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: ocm-agent-operator
+roleRef:
+  kind: Role
+  name: ocm-agent-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/RoleBinding-ocm-agent.yaml
+++ b/deploy_pko/RoleBinding-ocm-agent.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocm-agent
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: ocm-agent
+roleRef:
+  kind: Role
+  name: ocm-agent
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/ServiceAccount-ocm-agent-operator.yaml
+++ b/deploy_pko/ServiceAccount-ocm-agent-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/ServiceAccount-ocm-agent.yaml
+++ b/deploy_pko/ServiceAccount-ocm-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocm-agent
+  namespace: openshift-ocm-agent-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -1,0 +1,36 @@
+apiVersion: manifests.package-operator.run/v1alpha1
+kind: PackageManifest
+metadata:
+  name: ocm-agent-operator
+  annotations:
+    name: annotation
+spec:
+  scopes:
+  - Cluster
+  phases:
+  - name: crds
+  - name: namespace
+  - name: rbac
+  - name: deploy
+  - name: cleanup-rbac
+  - name: cleanup-deploy
+  availabilityProbes:
+  - probes:
+    - condition:
+        type: Available
+        status: 'True'
+    - fieldsEqual:
+        fieldA: .status.updatedReplicas
+        fieldB: .status.replicas
+    selector:
+      kind:
+        group: apps
+        kind: Deployment
+  config:
+    openAPIV3Schema:
+      properties:
+        image:
+          description: Operator image to deploy
+          type: string
+          default: None
+        type: object

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Template
+parameters:
+  - name: CHANNEL
+    required: false
+  - name: OPERATOR_IMAGE
+    required: true
+  - name: PKO_IMAGE
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE_DIGEST
+    required: true
+  - name: NAMESPACE
+    value: openshift-ocm-agent-operator
+  - name: REPO_NAME
+    value: ocm-agent-operator
+    required: true
+metadata:
+  name: selectorsyncset-template
+objects:
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: "true"
+      name: ocm-agent-operator-stage
+    spec:
+      clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      resourceApplyMode: Sync
+      resources:
+        - apiVersion: package-operator.run/v1alpha1
+          kind: ClusterPackage
+          metadata:
+            name: "${REPO_NAME}"
+            annotations:
+              package-operator.run/collision-protection: IfNoController
+          spec:
+            image: ${PKO_IMAGE}:${IMAGE_TAG}
+            config:
+              image: ${OPERATOR_IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
### What type of PR is this?
refactor


### What this PR does / why we need it?
Generated PKO manifests using boilerplate's `make pko-migrate` script:

  ### New Files Added

  - **`deploy_pko/`** - PKO manifests directory
    - 4 CRDs with `phase: crds` annotation
    - 8 RBAC resources with `phase: rbac` annotation
    - 1 Deployment template with `phase: deploy` annotation (uses Go templates)
    - 2 ServiceAccounts
    - 1 Cleanup Job for removing old OLM resources (phases: `cleanup-rbac`, `cleanup-deploy`)
    - 1 `manifest.yaml` (PackageManifest) defining 6 phases and availability probes

  - **`build/Dockerfile.pko`** - Dockerfile for building the PKO package image

  - **`hack/pko/clusterpackage.yaml`** - ClusterPackage template for deployment via app-interface

  - **`.tekton/ocm-agent-operator-pko-*.yaml`** - Konflux pipelines for building PKO package image

  ### Existing Files Unchanged

  - **`deploy/`** - Original OLM manifests remain intact for backward compatibility and GovCloud support

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SREP-3991](https://issues.redhat.com/browse/SREP-3991)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced pko variant of the ocm-agent-operator with deployment, operator, and CRD support for fleet notifications, notification records, and OCM agents

* **Chores**
  * Added RBAC, service accounts, role bindings, and package manifest for the new variant
  * Implemented post-migration cleanup job for OLM resources
  * Added CI/CD pipeline configs and packaging templates for pko builds; updated build base images and packaging Dockerfile
<!-- end of auto-generated comment: release notes by coderabbit.ai -->