### PR TITLE
Fixing pko PackageManifest

### DIFF
--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -33,4 +33,4 @@ spec:
           description: Operator image to deploy
           type: string
           default: None
-        type: object
+      type: object


### PR DESCRIPTION
### What type of PR is this?
Follow-up of https://github.com/openshift/ocm-agent-operator/pull/228

### What this PR does / why we need it?
The boilerplate creates the `type: object` is incorrectly nested inside properties.image. The PKO deployment was failing with a schema validation error:


```
  - lastTransitionTime: "2026-03-13T04:37:45Z"
     message: 'Invalid YAML in manifest.yaml: error unmarshaling JSON: while decoding
      JSON: json: cannot unmarshal string into Go struct field JSONSchemaProps.spec.config.openAPIV3Schema.properties
      of type v1.JSONSchemaProps'
     observedGeneration: 1
     reason: LoadError
     status: "True"
```
    
 object to the correct position at the openAPIV3Schema level.

### Which Jira/Github issue(s) this PR fixes?


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Fixed indentation formatting in manifest configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->