### PR TITLE
[SREP-3991] Add missing RBAC for openshift-config and openshift-monitoring namespaces to PKO

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694
 
 ENV USER_UID=1001 \
     USER_NAME=ocm-agent-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/Role-ocm-agent-operator.yaml
+++ b/deploy_pko/Role-ocm-agent-operator.yaml
@@ -77,3 +77,58 @@ rules:
   - patch
   - update
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: oao-openshiftconfig-reader
+  namespace: openshift-config
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: oao-monitoring-manager
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - watch
+  - list

--- a/deploy_pko/RoleBinding-ocm-agent-operator.yaml
+++ b/deploy_pko/RoleBinding-ocm-agent-operator.yaml
@@ -13,3 +13,37 @@ roleRef:
   kind: Role
   name: ocm-agent-operator
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: oao-openshiftconfig-reader
+  namespace: openshift-config
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: oao-openshiftconfig-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: oao-monitoring-manager
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: oao-monitoring-manager
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: ocm-agent-operator
+  namespace: openshift-ocm-agent-operator


### PR DESCRIPTION
### What type of PR is this?
refactor


### What this PR does / why we need it?

Add RBAC permissions for PKO deployment that were present in OLM but missing from PKO manifests.

  This PR adds the following namespace-specific RBAC resources:

  **openshift-config namespace:**
  - Role: `oao-openshiftconfig-reader` - grants get/list permissions for secrets
  - RoleBinding: binds the Role to `ocm-agent-operator` ServiceAccount

  **openshift-monitoring namespace:**
  - Role: `oao-monitoring-manager` - grants permissions for:
    - ConfigMaps (full CRUD)
    - ServiceMonitors (read-only)
    - NetworkPolicies (read-only)
  - RoleBinding: binds the Role to `ocm-agent-operator` ServiceAccount

  These permissions ensure PKO deployment has the same RBAC capabilities as the current OLM deployment.

  **Changes:**
  - Updated `deploy_pko/Role-ocm-agent-operator.yaml` with additional Role definitions
  - Updated `deploy_pko/RoleBinding-ocm-agent-operator.yaml` with additional RoleBindings

  **Reference:**
  OLM RBAC configuration: https://github.com/openshift/ocm-agent-operator/blob/master/hack/olm-registry/olm-artifacts-template.yaml#L90-L160

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://redhat.atlassian.net/browse/SREP-3991

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

