### PR TITLE
refactor: Optimize FleetMode checks and improve code clarity

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
 
 ENV USER_UID=1001 \
     USER_NAME=ocm-agent-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/pkg/ocmagenthandler/ocmagenthandler_configmap.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_configmap.go
@@ -81,22 +81,21 @@ func buildCAMOConfigMap(ocmAgent ocmagentv1alpha1.OcmAgent) (*corev1.ConfigMap, 
 func (o *ocmAgentHandler) ensureAllConfigMaps(ocmAgent ocmagentv1alpha1.OcmAgent) error {
 
 	// Ensure the OCM Agent ConfigMap
-	// Determine the cluster ID, used as a configmap value
-	cv, err := o.fetchClusterVersion()
-	if err != nil {
-		o.Log.Error(err, "unable to fetch cluster ID for creating configmap")
-		return err
-	}
-	clusterID := string(cv.Spec.ClusterID)
-
 	var oaCM *corev1.ConfigMap
+	// Only fetch cluster version for non-FleetMode to avoid unnecessary API calls
 	if ocmAgent.Spec.FleetMode {
 		oaCM = buildOCMAgentConfigMap(ocmAgent, "")
 	} else {
+		cv, err := o.fetchClusterVersion()
+		if err != nil {
+			o.Log.Error(err, "unable to fetch cluster ID for creating configmap")
+			return err
+		}
+		clusterID := string(cv.Spec.ClusterID)
 		oaCM = buildOCMAgentConfigMap(ocmAgent, clusterID)
 	}
 
-	err = o.ensureConfigMap(ocmAgent, oaCM, true)
+	err := o.ensureConfigMap(ocmAgent, oaCM, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/ocmagenthandler/ocmagenthandler_configmap_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_configmap_test.go
@@ -274,20 +274,16 @@ var _ = Describe("OCM Agent ConfigMap Handler", func() {
 		})
 
 		It("ensureAllConfigMaps handles fleet mode and errors", func() {
-			testClusterVersion := &configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{Name: "version"},
-				Spec:       configv1.ClusterVersionSpec{ClusterID: "test-cluster-id"},
-			}
-
-			// Test fleet mode (no CAMO, no cluster ID)
+			// Test fleet mode (no cluster version fetch, no CAMO, no cluster ID)
 			testOcmAgent.Spec.FleetMode = true
-			mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *testClusterVersion)
+			// FleetMode creates: OCM Agent ConfigMap + Trusted CA ConfigMap (not CAMO)
 			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(k8serrs.NewNotFound(schema.GroupResource{}, "")).Times(2)
 			mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			err := testOcmAgentHandler.ensureAllConfigMaps(testOcmAgent)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Test cluster version fetch error
+			// Test non-fleet mode cluster version fetch error
+			testOcmAgent.Spec.FleetMode = false
 			fetchError := errors.New("fetch failed")
 			mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).Return(fetchError)
 			err = testOcmAgentHandler.ensureAllConfigMaps(testOcmAgent)

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment.go
@@ -238,8 +238,7 @@ func buildOCMAgentArgs(ocmAgent ocmagentv1alpha1.OcmAgent) []string {
 	}
 	if !ocmAgent.Spec.FleetMode {
 		command = append(command, fmt.Sprintf("--cluster-id=@%s", clusterIDPath), fmt.Sprintf("--access-token=@%s", accessTokenPath))
-	}
-	if ocmAgent.Spec.FleetMode {
+	} else {
 		command = append(command, "--fleet-mode")
 	}
 

--- a/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_networkpolicy.go
@@ -70,13 +70,18 @@ func buildNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent, namespace string) ne
 	return np
 }
 
-func (o *ocmAgentHandler) ensureAllNetworkPolicies(ocmAgent ocmagentv1alpha1.OcmAgent) error {
+func getNetworkPolicyNamespaces(ocmAgent ocmagentv1alpha1.OcmAgent) []string {
 	var namespaces []string
 	if ocmAgent.Spec.FleetMode {
 		namespaces = append(namespaces, oah.NamespaceMonitorng, oah.NamespaceRHOBS, oah.NamespaceOBO)
 	} else {
 		namespaces = append(namespaces, oah.NamespaceMonitorng, oah.NamespaceMUO)
 	}
+	return namespaces
+}
+
+func (o *ocmAgentHandler) ensureAllNetworkPolicies(ocmAgent ocmagentv1alpha1.OcmAgent) error {
+	namespaces := getNetworkPolicyNamespaces(ocmAgent)
 	for _, ns := range namespaces {
 		err := o.ensureNetworkPolicy(ocmAgent, ns)
 		if err != nil {
@@ -134,12 +139,7 @@ func (o *ocmAgentHandler) ensureNetworkPolicy(ocmAgent ocmagentv1alpha1.OcmAgent
 }
 
 func (o *ocmAgentHandler) ensureAllNetworkPoliciesDeleted(ocmAgent ocmagentv1alpha1.OcmAgent) error {
-	var namespaces []string
-	if ocmAgent.Spec.FleetMode {
-		namespaces = append(namespaces, oah.NamespaceMonitorng, oah.NamespaceRHOBS, oah.NamespaceOBO)
-	} else {
-		namespaces = append(namespaces, oah.NamespaceMonitorng, oah.NamespaceMUO)
-	}
+	namespaces := getNetworkPolicyNamespaces(ocmAgent)
 	for _, ns := range namespaces {
 		err := o.ensureNetworkPolicyDeleted(ocmAgent, ns)
 		if err != nil {


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_


### What this PR does / why we need it?
Minor optimizations and code clarity improvements in OCM Agent handler.

  1. Skip cluster version fetch in FleetMode (`ocmagenthandler_configmap.go`)
  - Fleet mode doesn't use cluster ID, so skip the cluster version API call
  - Reduces unnecessary API calls in fleet mode scenarios

  2. Extract namespace logic to helper function (ocmagenthandler_networkpolicy.go)
  - Removed code duplication by extracting getNetworkPolicyNamespaces()
  - Improves maintainability

  3. Clarify mutually exclusive conditions (ocmagenthandler_deployment.go)
  - Changed two separate if statements to if-else
  - Makes it explicit that FleetMode and non-FleetMode are mutually exclusive

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ N/A

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Optimized cluster detection and config behavior when FleetMode is enabled vs disabled
  * Refined agent startup flag selection to ensure mutually exclusive mode flags
  * Unified network-policy namespace selection for consistent behavior across modes
* **Tests**
  * Updated unit tests to reflect FleetMode-specific behavior and error paths
* **Chores**
  * Updated runtime base image tag used for container builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->