### PR TITLE
SREP-4484: Test codecov changes for ocm-agent

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,8 +8,14 @@ coverage:
   range: "20...100"
 
   status:
-    project: no
-    patch: no
+    project:
+      default:
+        target: 50%
+        threshold: 1%
+    patch:
+      default:
+        target: 50%
+        threshold: 1%
     changes: no
 
 parsers:


### PR DESCRIPTION
### What type of PR is this?
_test_


### What this PR does / why we need it?
As a part of [SREP-4484](https://redhat.atlassian.net/browse/SREP-4484), I want to enable codecov to have a minimum threshold for coverage. This PR is to test the MVP before merging in boilerplate https://github.com/openshift/boilerplate/pull/720

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



[SREP-4484]: https://redhat.atlassian.net/browse/SREP-4484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to enable coverage reporting and establish quality benchmarks with a 50% coverage target and 1% variance threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->