### PR TITLE
SREP-4556: Add terminationMessagePolicy for OCP 4.21 conformance

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 
 ENV USER_UID=1001 \
     USER_NAME=ocm-agent-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/50_ocm-agent-operator.Deployment.yaml
+++ b/deploy/50_ocm-agent-operator.Deployment.yaml
@@ -40,6 +40,7 @@ spec:
           command:
             - ocm-agent-operator
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: WATCH_NAMESPACE
               value: "openshift-ocm-agent-operator"

--- a/deploy_pko/.test-fixtures/config-with-proxy/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/config-with-proxy/Cleanup-OLM-Job.yaml
@@ -76,6 +76,7 @@ spec:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - sh
             - -c

--- a/deploy_pko/.test-fixtures/config-with-proxy/Deployment-ocm-agent-operator.yaml
+++ b/deploy_pko/.test-fixtures/config-with-proxy/Deployment-ocm-agent-operator.yaml
@@ -42,6 +42,7 @@ spec:
         command:
         - ocm-agent-operator
         imagePullPolicy: Always
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
         - name: WATCH_NAMESPACE
           value: openshift-ocm-agent-operator

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -76,6 +76,7 @@ spec:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - sh
             - -c

--- a/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
@@ -42,6 +42,7 @@ spec:
         command:
         - ocm-agent-operator
         imagePullPolicy: Always
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
         - name: WATCH_NAMESPACE
           value: openshift-ocm-agent-operator


### PR DESCRIPTION
Adds terminationMessagePolicy: FallbackToLogsOnError to all containers in deploy/ and deploy_pko/ manifests (including test fixtures). Required for OCP 4.21 conformance (terminationMessagePolicy monitor test).

Jira: https://redhat.atlassian.net/browse/SREP-4556
Reference: openshift/route-monitor-operator#516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message capture by configuring containers to fall back to logs when errors occur.

* **Chores**
  * Updated container runtime base images to latest versions for improved stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->