### PR TITLE
Bump the OAO CPU and memory usage to align with OA

### DIFF
--- a/deploy_pko/.test-fixtures/config-with-proxy/Deployment-ocm-agent-operator.yaml
+++ b/deploy_pko/.test-fixtures/config-with-proxy/Deployment-ocm-agent-operator.yaml
@@ -37,8 +37,8 @@ spec:
             memory: 40Mi
             cpu: 1m
           limits:
-            memory: 64Mi
-            cpu: 10m
+            memory: 128Mi
+            cpu: 50m
         command:
         - ocm-agent-operator
         imagePullPolicy: Always

--- a/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
@@ -37,8 +37,8 @@ spec:
             memory: 40Mi
             cpu: 1m
           limits:
-            memory: 64Mi
-            cpu: 10m
+            memory: 128Mi
+            cpu: 50m
         command:
         - ocm-agent-operator
         imagePullPolicy: Always


### PR DESCRIPTION
### What type of PR is this?
Bump the OAO CPU and memory usage to align with OA


### What this PR does / why we need it?
OAO is crashing on customer cluster and we found resource limit reached.


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased container resource limits for the agent operator to improve stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->