### PR TITLE
chore(SREP-4459) add standardized CLAUDE.md

### DIFF
--- a/.claude/hooks/stop-prek-validation.sh
+++ b/.claude/hooks/stop-prek-validation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+HOOK_INPUT=$(cat)
+
+# Check for retry loop WITHOUT requiring jq (prevents infinite loop)
+if echo "$HOOK_INPUT" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+  exit 0
+fi
+
+# Check for jq (will block FIRST time, but loop protection above prevents infinite loop)
+if ! command -v jq &>/dev/null; then
+  echo '{"decision": "block", "reason": "jq is not installed. Install jq to use prek validation hooks. See CONTRIBUTING.md for setup instructions."}'
+  exit 0
+fi
+
+# jq is available - use it to check loop protection properly
+STOP_HOOK_ACTIVE=$(echo "$HOOK_INPUT" | jq -r '.stop_hook_active // false')
+if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
+  exit 0
+fi
+
+# Check for prek
+if ! command -v prek &>/dev/null; then
+  jq -n --arg reason "prek is not installed. Install prek to use validation hooks. See CONTRIBUTING.md for setup instructions." \
+    '{"decision": "block", "reason": $reason}'
+  exit 0
+fi
+
+# Run prek validation
+PREK_OUTPUT=$(prek run --all-files 2>&1)
+PREK_EXIT=$?
+
+if [[ $PREK_EXIT -eq 0 ]]; then
+  exit 0
+fi
+
+# Block stop and tell Claude what to fix
+jq -n \
+  --arg reason "prek run --all-files failed. Fix the issues below, then try again:
+
+$PREK_OUTPUT" \
+  '{"decision": "block", "reason": $reason}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(prek run --all-files)",
+      "Bash(make go-check)",
+      "Bash(make lint)"
+    ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop-prek-validation.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,12 @@ boilerplate/_lib/container-make        # Run make inside boilerplate container
 boilerplate/_lib/container-make generate  # Generate mocks in container environment
 ```
 
+## Development Workflow
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for complete setup instructions, validation commands, and testing procedures.
+
+**Note for Claude Code users:** The stop hook automatically runs `prek run --all-files` before Claude stops, catching validation issues early. Human developers should follow the setup in CONTRIBUTING.md to install pre-commit hooks.
+
 ## Architecture
 
 ### Core Components

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing to Ocm Agent Operator
+
+Thank you for your interest in contributing! This guide provides comprehensive instructions for setting up your development environment, running tests, and contributing code to this operator.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Pre-commit Hooks with prek](#pre-commit-hooks-with-prek)
+- [Claude Code Integration](#claude-code-integration)
+- [Commit Message Conventions](#commit-message-conventions)
+- [PR Process & Review Requirements](#pr-process--review-requirements)
+- [Validation and Linting](#validation-and-linting)
+- [Testing](#testing)
+- [Boilerplate Framework](#boilerplate-framework)
+- [CI/CD Integration](#cicd-integration)
+
+
+## Code of Conduct
+
+As contributors and maintainers of this project, we are committed to making participation a harassment-free experience for everyone. In short, be excellent to each other.
+
+## Prerequisites
+
+Before contributing, ensure you have the following tools installed:
+
+- **Go 1.22+**: [Installation guide](https://golang.org/doc/install)
+- **golangci-lint**: Used for Go code linting.
+- **[prek](https://prek.j178.dev/)**: Git hook manager that runs validation automatically on commit.
+
+## Setup
+
+```bash
+# Install prek (macOS)
+brew install prek
+
+# Install prek (Linux)
+curl -fsSL https://prek.j178.dev/install.sh | bash
+
+# Install pre-commit hooks in this repository
+prek install
+```
+
+`prek install` sets up git hooks that automatically run file hygiene checks and `golangci-lint` before each commit.
+
+## Pre-commit Hooks with prek
+
+The validation runs automatically via pre-commit hooks, or you can run it manually:
+
+```bash
+# Run all validations (file hygiene + golangci-lint)
+prek run --all-files
+
+# Run only golangci-lint via make
+make go-check
+```
+
+## Claude Code Integration
+
+### Stop Hook: prek Validation on Every Turn
+
+If you use **Claude Code**, this repository includes a [stop hook](https://docs.anthropic.com/en/docs/claude-code/hooks) in `.claude/settings.json` that runs `prek run --all-files` every time Claude finishes a turn. 
+
+If `prek` finds violations (trailing whitespace, linting errors, etc.), the hook **blocks Claude from stopping** and feeds the errors back so Claude can fix them automatically. This shortens the feedback loop and ensures high-quality output without manual intervention.
+
+## Commit Message Conventions
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for all commit messages.
+
+### AI Attribution
+
+When using AI assistants (like Claude, Gemini, or GitHub Copilot) to generate or significantly refactor code, you **MUST** include an attribution in the commit message trailer.
+
+Use the `Co-authored-by` trailer format:
+
+```text
+feat(api): add new validation for PagerDutyIntegration
+
+This commit adds a new validating webhook.
+
+Co-authored-by: Claude <claude@anthropic.com>
+```
+
+## PR Process & Review Requirements
+
+### Submission Guidelines
+1. **Branching**: Create a feature branch for your changes.
+2. **Tests**: New features and bug fixes should include appropriate unit or integration tests.
+3. **Docs**: Update relevant documentation if changing user-facing behavior.
+
+### Review Process
+- **CI Passing**: All automated tests in PROW must pass.
+- **Peer Review**: At least one `/lgtm` (Look Good To Me) from a maintainer is required.
+- **Approval**: An `/approve` label from a designated code owner is required for merging.
+- **Merge Bot**: Once approved and CI is green, the OpenShift Merge Bot will automatically merge the PR.
+
+## Validation and Linting
+
+This project uses `golangci-lint` configured via the boilerplate framework.
+
+```bash
+# Run full validation (boilerplate + lint)
+make lint
+
+# Run only golangci-lint
+make go-check
+```
+
+## Testing
+
+```bash
+# Run unit tests
+make test
+
+# Run code coverage
+make coverage
+```
+
+
+## Boilerplate Framework
+
+This repository uses the [openshift/boilerplate](https://github.com/openshift/boilerplate/) framework. 
+
+Key boilerplate targets:
+- `make validate` — Check code generation and boilerplate consistency.
+- `make lint` — Static analysis and YAML validation.
+- `make test` — Run the standard test suite.
+
+## CI/CD Integration
+
+The project uses **OpenShift PROW** for continuous integration. Every pull request triggers a set of jobs defined in the `openshift/release` repository that execute `make validate`, `make lint`, and `make test`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing! This guide provides comprehensive i
 - [Testing](#testing)
 - [Boilerplate Framework](#boilerplate-framework)
 - [CI/CD Integration](#cicd-integration)
-
+- [Additional Resources](#additional-resources)
 
 ## Code of Conduct
 
@@ -32,6 +32,12 @@ Before contributing, ensure you have the following tools installed:
 ## Setup
 
 ```bash
+# Install golangci-lint (macOS)
+brew install golangci-lint
+
+# Install golangci-lint (Linux)
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+
 # Install prek (macOS)
 brew install prek
 
@@ -117,6 +123,8 @@ make test
 make coverage
 ```
 
+*For detailed testing instructions for this specific operator, please see [docs/testing.md](docs/testing.md).*
+
 
 ## Boilerplate Framework
 
@@ -130,3 +138,8 @@ Key boilerplate targets:
 ## CI/CD Integration
 
 The project uses **OpenShift PROW** for continuous integration. Every pull request triggers a set of jobs defined in the `openshift/release` repository that execute `make validate`, `make lint`, and `make test`.
+
+## Additional Resources
+
+- [docs/development.md](docs/development.md)
+- [docs/design.md](docs/design.md)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
 
 ENV USER_UID=1001 \
     USER_NAME=ocm-agent-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/crds/ocmagent.managed.openshift.io_managedfleetnotificationrecords.yaml
+++ b/deploy/crds/ocmagent.managed.openshift.io_managedfleetnotificationrecords.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: managedfleetnotificationrecords.ocmagent.managed.openshift.io
 spec:
   group: ocmagent.managed.openshift.io

--- a/deploy/crds/ocmagent.managed.openshift.io_managedfleetnotifications.yaml
+++ b/deploy/crds/ocmagent.managed.openshift.io_managedfleetnotifications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: managedfleetnotifications.ocmagent.managed.openshift.io
 spec:
   group: ocmagent.managed.openshift.io

--- a/deploy/crds/ocmagent.managed.openshift.io_managednotifications.yaml
+++ b/deploy/crds/ocmagent.managed.openshift.io_managednotifications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: managednotifications.ocmagent.managed.openshift.io
 spec:
   group: ocmagent.managed.openshift.io

--- a/deploy/crds/ocmagent.managed.openshift.io_ocmagents.yaml
+++ b/deploy/crds/ocmagent.managed.openshift.io_ocmagents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ocmagents.ocmagent.managed.openshift.io
 spec:
   group: ocmagent.managed.openshift.io

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -1,0 +1,496 @@
+# Claude Code Usage Guide for ocm-agent-operator
+
+This guide explains how to use Claude Code effectively with this operator repository.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Available Skills](#available-skills)
+- [Review Agents](#review-agents)
+- [Hooks](#hooks)
+- [Common Workflows](#common-workflows)
+- [Tips & Best Practices](#tips--best-practices)
+
+## Getting Started
+
+### What is Claude Code?
+
+Claude Code is an AI-powered development assistant that helps with:
+- Code review and quality analysis
+- Writing and refactoring code
+- Running tests and debugging
+- Understanding codebases
+- Following repository conventions
+
+### Installation
+
+Claude Code is available as:
+- **CLI**: `claude` command in terminal
+- **Desktop App**: Mac/Windows application
+- **Web App**: https://claude.ai/code
+- **IDE Extensions**: VS Code, JetBrains
+
+### First Time Setup
+
+1. Navigate to the repository:
+```bash
+cd ~/rh-projects/ROSA-730/ocm-agent-operator
+```
+
+2. Start Claude Code:
+```bash
+claude
+# or use the desktop/web app
+```
+
+3. Claude automatically loads:
+   - `CLAUDE.md` - Repository-specific guidance
+   - `.claude/settings.json` - Permissions and hooks
+   - `.claude/skills/` - Custom commands
+   - `.claude/agents/` - Specialized review agents
+
+## Available Skills
+
+Skills are custom slash commands for common tasks. Type `/` to see all available skills.
+
+### `/full-review`
+
+Run comprehensive code review with security, linting, test coverage, and error handling analysis.
+
+**Usage:**
+```
+/full-review
+```
+
+**What it runs:**
+- Security review (OWASP Top 10, RBAC, secrets)
+- Linting via `make lint` (golangci-lint)
+- Test coverage analysis (gaps, quality)
+- Error handling review (wrapping, logging)
+
+**When to use:**
+- Before creating a PR
+- After making significant changes
+- When reviewing someone else's code
+
+**Output:** Severity-organized report from all review agents
+
+---
+
+### `/run-tests`
+
+Execute the full test suite including linting, unit tests, and race detection.
+
+**Usage:**
+```
+/run-tests
+/run-tests with race detection
+/run-tests quick
+```
+
+**What it runs:**
+- `make lint` - golangci-lint checks
+- `make test` - Unit tests with coverage
+- `go test -race` - Race condition detection
+- `make go-build` - Build verification
+
+---
+
+### `/update-crds`
+
+Regenerate CRDs and manifests after modifying API types.
+
+**Usage:**
+```
+/update-crds
+```
+
+**When to use:**
+- After changing `api/v1alpha1/*.go` files
+- After adding/modifying kubebuilder markers
+- After changing RBAC requirements
+
+**What it does:**
+- Runs `make manifests` - Updates CRDs and RBAC
+- Runs `make generate` - Updates generated code
+
+---
+
+## Review Agents
+
+Agents are specialized AI assistants for focused code analysis. They run in isolated worktrees in the background.
+
+### Available Agents
+
+| Agent | Focus Area | Usage |
+|-------|-----------|-------|
+| `@security-reviewer` | OWASP Top 10, RBAC, secrets | `@security-reviewer` |
+| `@lint-reviewer` | Code quality using golangci-lint | `@lint-reviewer` |
+| `@test-reviewer` | Coverage, test quality | `@test-reviewer` |
+| `@error-handling-reviewer` | Error handling patterns | `@error-handling-reviewer` |
+
+### Manual Code Quality Checks
+
+For performance and concurrency analysis, use the existing tooling:
+
+| Tool | Focus Area | Command |
+|------|-----------|---------|
+| Race detector | Concurrency issues | `go test -race ./...` |
+| Profiling | Performance bottlenecks | `go test -cpuprofile=cpu.prof -bench=.` |
+
+### Running Individual Agents
+
+You can invoke agents individually for focused reviews:
+
+```
+@security-reviewer
+```
+
+Or with specific instructions:
+
+```
+@security-reviewer focus on RBAC permissions in the new controller
+```
+
+### Agent Review Scope
+
+All agents review **only the diff** between your branch and `master`:
+```bash
+git diff master...HEAD
+```
+
+They won't report issues in unchanged code.
+
+## Hooks
+
+Hooks are automated scripts that run during Claude Code workflows.
+
+### `user-prompt-submit`
+
+**Triggers:** When you submit a prompt to Claude  
+**Purpose:** Reminds you to run tests after code changes
+
+**Example output:**
+```
+📝 Code changes detected. After changes, remember to:
+   • make lint  - Run golangci-lint
+   • make test  - Run unit tests
+```
+
+### `before-commit`
+
+**Triggers:** Before Claude creates a git commit  
+**Purpose:** Runs validation to catch issues early
+
+**What it runs:**
+1. `make lint` - Linting must pass
+2. `make test` - Tests must pass
+
+**Note:** This runs *in addition* to git pre-commit hooks (if configured).
+
+## Common Workflows
+
+### Workflow 1: Implementing a New Feature
+
+```
+1. You: "Add a new field 'retryCount' to MyResource spec with validation"
+
+2. Claude: [Modifies api/v1alpha1/myresource_types.go]
+
+3. You: "/update-crds"
+   Claude: [Runs make manifests && make generate]
+
+4. You: "Now update the controller to use this field"
+   Claude: [Modifies controller logic]
+
+5. You: "/run-tests"
+   Claude: [Runs lint + tests]
+
+6. You: "Create a commit"
+   Claude: [before-commit hook runs tests, then creates commit]
+```
+
+### Workflow 2: Pre-PR Code Review
+
+```bash
+# On your feature branch
+git checkout feature/my-awesome-feature
+
+# Start Claude Code
+claude
+```
+
+```
+You: "/full-review"
+
+Claude: [Launches all 5 review agents in parallel]
+
+        ## Full Review Report
+
+        ### Security Review
+        ✅ No critical issues found
+
+        ### Performance Review
+        🔴 1 high severity: Inefficient API calls in reconcile loop
+        [Details and fix suggestions]
+
+        ### Test Review
+        🔴 2 high severity: Missing test coverage for error paths
+        [Details and suggested tests]
+
+        ### Error Handling Review
+        ⚠️  3 medium: Missing error wrapping
+        [Details]
+
+        ### Concurrency Review
+        ✅ No issues found
+
+        ---
+        Summary: 3 high, 3 medium issues found
+        Estimated fix time: 1-2 hours
+```
+
+```
+You: "Fix the high severity issues"
+
+Claude: [Makes fixes]
+
+You: "/run-tests"  # Verify fixes work
+
+You: "/full-review"  # Re-review to confirm
+```
+
+### Workflow 3: Debugging Test Failures
+
+```
+You: "Tests are failing in TestReconcile"
+
+Claude: [Reads test file, analyzes failure]
+
+You: "Run the test with -v flag"
+
+Claude: [Runs go test -v ./controllers/... -run TestReconcile]
+
+You: "Fix the assertion"
+
+Claude: [Updates test]
+
+You: "/run-tests"  # Verify fix
+```
+
+### Workflow 4: Understanding Code
+
+```
+You: "Explain how the reconciliation loop works"
+
+Claude: [Reads controller code, explains flow with references]
+
+You: "Show me where we update the status"
+
+Claude: [Shows specific lines with file:line references]
+
+You: "What happens if the resource is being deleted?"
+
+Claude: [Explains finalizer logic with code examples]
+```
+
+### Workflow 5: Creating a PR
+
+```
+You: "I'm ready to create a PR for this feature"
+
+Claude: [Runs full review first]
+
+You: "Create a PR"
+
+Claude:
+   1. Runs git status, git diff
+   2. Checks all commits
+   3. Drafts PR title and description
+   4. Pushes branch
+   5. Creates PR via gh CLI
+   6. Returns PR URL
+```
+
+## Tips & Best Practices
+
+### DO
+
+✅ **Run `/full-review` before creating PRs**  
+Catches issues early, reduces review cycles
+
+✅ **Use hooks to automate validation**  
+Less manual work, fewer mistakes
+
+✅ **Let agents run in background**  
+Continue working while agents analyze code
+
+✅ **Review agent findings critically**  
+Agents are smart but not perfect - use judgment
+
+✅ **Provide context in prompts**  
+"Add rate limiting to the reconciler" is better than "add rate limiting"
+
+✅ **Use specific agent for focused review**  
+`@security-reviewer` is faster than full review if you only changed auth code
+
+### DON'T
+
+❌ **Don't ignore Critical/High findings**  
+These often indicate real bugs
+
+❌ **Don't bypass hooks**  
+They exist to maintain quality
+
+❌ **Don't commit without testing**  
+Hooks will catch this, but test earlier
+
+❌ **Don't assume agents know your intent**  
+Provide context about business logic and constraints
+
+❌ **Don't forget to re-review after fixes**  
+Verify your changes actually addressed the issues
+
+### Performance Tips
+
+**Fast feedback:**
+```
+/run-tests quick  # Skips slow integration tests
+```
+
+**Parallel agent review:**
+```
+/full-review  # All agents run in parallel, faster than sequential
+```
+
+**Cache informer:**  
+Agents use git worktrees, so your working directory stays clean
+
+### Keyboard Shortcuts (if using desktop/IDE)
+
+- `Ctrl+L` - Clear conversation
+- `Ctrl+K` - New conversation
+- `↑` - Previous prompt
+- `Tab` - Autocomplete skill names
+
+### Getting Help
+
+**Within Claude Code:**
+```
+/help
+```
+
+**Repository-specific help:**
+```
+Read docs/CLAUDE_CODE_GUIDE.md  # This file
+```
+
+**Feedback & Issues:**
+- General Claude Code: https://github.com/anthropics/claude-code/issues
+- This repo's setup: Create issue in ocm-agent-operator repo
+
+## Advanced Usage
+
+### Custom Agents
+
+You can create custom agents in `.claude/agents/`:
+
+```markdown
+---
+name: my-custom-reviewer
+description: Reviews XYZ aspects
+model: sonnet
+---
+
+Review instructions here...
+```
+
+Then use with: `@my-custom-reviewer`
+
+### Custom Skills
+
+Create custom skills in `.claude/skills/`:
+
+```markdown
+---
+name: my-skill
+description: Does something useful
+---
+
+Skill instructions here...
+```
+
+Then use with: `/my-skill`
+
+### Permissions
+
+Adjust in `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read:*",
+      "Bash:make *",
+      "Bash:go test *"
+    ]
+  }
+}
+```
+
+### Environment Variables
+
+Set operator-specific env vars in `.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "KUBECONFIG": "/path/to/kubeconfig",
+    "OPERATOR_NAMESPACE": "test-namespace"
+  }
+}
+```
+
+## Troubleshooting
+
+### "Permission denied for Bash tool"
+
+Add to `.claude/settings.json`:
+```json
+{
+  "permissions": {
+    "allow": ["Bash:your-command *"]
+  }
+}
+```
+
+### "Agent failed to run"
+
+Check:
+- Git is installed and repo has commits
+- Branch is checked out (not detached HEAD)
+- Enough disk space for worktree
+
+### "Hooks are not running"
+
+Verify:
+- Hooks are executable: `chmod +x .claude/hooks/*`
+- Hooks have correct shebang: `#!/bin/bash`
+- Settings.json references hooks correctly
+
+### "Skill not found"
+
+- Skill files must be in `.claude/skills/`
+- Must have frontmatter with `name:` field
+- Use exact name: `/full-review` not `/fullreview`
+
+## Resources
+
+- [Claude Code Documentation](https://docs.anthropic.com/claude-code)
+- [OSD Operator Guide](https://github.com/openshift/ops-sop/blob/master/operators/README.md)
+- [Boilerplate Documentation](https://github.com/openshift/boilerplate)
+- [SREP-4410: Claude Integration Epic](https://issues.redhat.com/browse/SREP-4410)
+
+---
+
+**Questions?** Ask Claude! It has context about this entire setup.

--- a/pkg/util/test/generated/mocks/client/cr-client.go
+++ b/pkg/util/test/generated/mocks/client/cr-client.go
@@ -17,7 +17,6 @@ import (
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,6 +24,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.
@@ -45,10 +45,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...client.CreateOption) error {
+func (m *MockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Create", varargs...)
@@ -57,17 +57,17 @@ func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockClientMockRecorder) Create(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Create(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), varargs...)
 }
 
 // Delete mocks base method.
-func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteOption) error {
+func (m *MockClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Delete", varargs...)
@@ -76,17 +76,17 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Delete(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
 }
 
 // DeleteAllOf mocks base method.
-func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteAllOfOption) error {
+func (m *MockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "DeleteAllOf", varargs...)
@@ -95,17 +95,17 @@ func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 
 }
 
 // DeleteAllOf indicates an expected call of DeleteAllOf.
-func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteAllOf(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOf", reflect.TypeOf((*MockClient)(nil).DeleteAllOf), varargs...)
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 client.Object, arg3 ...client.GetOption) error {
+func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, key, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Get", varargs...)
@@ -114,47 +114,47 @@ func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 c
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Get(ctx, key, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, key, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), varargs...)
 }
 
 // GroupVersionKindFor mocks base method.
-func (m *MockClient) GroupVersionKindFor(arg0 runtime.Object) (schema.GroupVersionKind, error) {
+func (m *MockClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GroupVersionKindFor", arg0)
+	ret := m.ctrl.Call(m, "GroupVersionKindFor", obj)
 	ret0, _ := ret[0].(schema.GroupVersionKind)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GroupVersionKindFor indicates an expected call of GroupVersionKindFor.
-func (mr *MockClientMockRecorder) GroupVersionKindFor(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) GroupVersionKindFor(obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupVersionKindFor", reflect.TypeOf((*MockClient)(nil).GroupVersionKindFor), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupVersionKindFor", reflect.TypeOf((*MockClient)(nil).GroupVersionKindFor), obj)
 }
 
 // IsObjectNamespaced mocks base method.
-func (m *MockClient) IsObjectNamespaced(arg0 runtime.Object) (bool, error) {
+func (m *MockClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsObjectNamespaced", arg0)
+	ret := m.ctrl.Call(m, "IsObjectNamespaced", obj)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsObjectNamespaced indicates an expected call of IsObjectNamespaced.
-func (mr *MockClientMockRecorder) IsObjectNamespaced(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) IsObjectNamespaced(obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsObjectNamespaced", reflect.TypeOf((*MockClient)(nil).IsObjectNamespaced), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsObjectNamespaced", reflect.TypeOf((*MockClient)(nil).IsObjectNamespaced), obj)
 }
 
 // List mocks base method.
-func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...client.ListOption) error {
+func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, list}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "List", varargs...)
@@ -163,17 +163,17 @@ func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...
 }
 
 // List indicates an expected call of List.
-func (mr *MockClientMockRecorder) List(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) List(ctx, list any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, list}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
 // Patch mocks base method.
-func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
+func (m *MockClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, obj, patch}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Patch", varargs...)
@@ -182,9 +182,9 @@ func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Patch(ctx, obj, patch any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, obj, patch}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), varargs...)
 }
 
@@ -231,24 +231,24 @@ func (mr *MockClientMockRecorder) Status() *gomock.Call {
 }
 
 // SubResource mocks base method.
-func (m *MockClient) SubResource(arg0 string) client.SubResourceClient {
+func (m *MockClient) SubResource(subResource string) client.SubResourceClient {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubResource", arg0)
+	ret := m.ctrl.Call(m, "SubResource", subResource)
 	ret0, _ := ret[0].(client.SubResourceClient)
 	return ret0
 }
 
 // SubResource indicates an expected call of SubResource.
-func (mr *MockClientMockRecorder) SubResource(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) SubResource(subResource any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubResource", reflect.TypeOf((*MockClient)(nil).SubResource), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubResource", reflect.TypeOf((*MockClient)(nil).SubResource), subResource)
 }
 
 // Update mocks base method.
-func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.UpdateOption) error {
+func (m *MockClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Update", varargs...)
@@ -257,9 +257,9 @@ func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockClientMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Update(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockClient)(nil).Update), varargs...)
 }
 
@@ -267,6 +267,7 @@ func (mr *MockClientMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Ca
 type MockStatusWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockStatusWriterMockRecorder
+	isgomock struct{}
 }
 
 // MockStatusWriterMockRecorder is the mock recorder for MockStatusWriter.
@@ -287,10 +288,10 @@ func (m *MockStatusWriter) EXPECT() *MockStatusWriterMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockStatusWriter) Create(arg0 context.Context, arg1, arg2 client.Object, arg3 ...client.SubResourceCreateOption) error {
+func (m *MockStatusWriter) Create(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceCreateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, obj, subResource}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Create", varargs...)
@@ -299,17 +300,17 @@ func (m *MockStatusWriter) Create(arg0 context.Context, arg1, arg2 client.Object
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockStatusWriterMockRecorder) Create(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Create(ctx, obj, subResource any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, obj, subResource}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockStatusWriter)(nil).Create), varargs...)
 }
 
 // Patch mocks base method.
-func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.SubResourcePatchOption) error {
+func (m *MockStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, obj, patch}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Patch", varargs...)
@@ -318,17 +319,17 @@ func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockStatusWriterMockRecorder) Patch(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Patch(ctx, obj, patch any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, obj, patch}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockStatusWriter)(nil).Patch), varargs...)
 }
 
 // Update mocks base method.
-func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.SubResourceUpdateOption) error {
+func (m *MockStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Update", varargs...)
@@ -337,8 +338,8 @@ func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockStatusWriterMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Update(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockStatusWriter)(nil).Update), varargs...)
 }

--- a/pkg/util/test/generated/mocks/ocmagenthandler/interfaces.go
+++ b/pkg/util/test/generated/mocks/ocmagenthandler/interfaces.go
@@ -22,6 +22,7 @@ import (
 type MockOcmAgentHandlerBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockOcmAgentHandlerBuilderMockRecorder
+	isgomock struct{}
 }
 
 // MockOcmAgentHandlerBuilderMockRecorder is the mock recorder for MockOcmAgentHandlerBuilder.
@@ -60,6 +61,7 @@ func (mr *MockOcmAgentHandlerBuilderMockRecorder) New() *gomock.Call {
 type MockOCMAgentHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockOCMAgentHandlerMockRecorder
+	isgomock struct{}
 }
 
 // MockOCMAgentHandlerMockRecorder is the mock recorder for MockOCMAgentHandler.


### PR DESCRIPTION
What type of PR is this?
documentation

What this PR does / why we need it?
This PR updates the repository's documentation as part of the Agentic SDLC Rollout.
 - It introduces a standardized CONTRIBUTING.md file at the root.
 - It updates CLAUDE.md to include a "Development Workflow" section and specific notes for Claude Code users regarding the automated pre-commit validation (stop hooks).

Which Jira/Github issue(s) this PR fixes?
Part of Rollout for Agentic SDLC -
 - CLAUDE.md standardization - [SREP-4459](https://redhat.atlassian.net/browse/SREP-4459) (https://redhat.atlassian.net/browse/SREP-4459)

Special notes for your reviewer:
This change ensures that both human developers and AI assistants have a clear, unified path for environment setup and commit validation.

Pre-checks (if applicable):
 - [ ] Tested latest changes against a cluster
 - [ ] Ran make generate command locally to validate code changes
 - [x] Included documentation changes with PR

[SREP-4459]: https://redhat.atlassian.net/browse/SREP-4459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ