### PR TITLE
ROSA-745: revert pilot fork renovate extends to openshift/boilerplate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>MitaliBhalla/boilerplate#draft/rosa-745-gomod-batch-monday//.github/renovate.json"
+    "github>openshift/boilerplate//.github/renovate.json"
   ]
 }


### PR DESCRIPTION
## Summary

Reverts the #285 pilot change that pointed `.github/renovate.json` at `MitaliBhalla/boilerplate#draft/rosa-745-gomod-batch-monday` and restores the fleet-standard upstream extends:

```json
"github>openshift/boilerplate//.github/renovate.json"
```

**Unchanged:** `.github/dependabot.yml` docker labels (`lgtm`/`approved`) and Mon 03:00 UTC schedule from #285.

## Why

- Pilot fork is no longer needed; openshift/boilerplate#748 carries the gomod MintMaker config on upstream.
- Aligns ocm-agent-operator with other operators that inherit renovate from upstream boilerplate.

## After merge

- **Before #748 merges:** upstream renovate is tekton-only (same as pre-pilot production boilerplate).
- **After #748 merges:** this repo picks up grouped gomod MintMaker rules automatically via extends (no fork).

## Follow-up

- Close stale Dependabot gomod PR [#240](https://github.com/openshift/ocm-agent-operator/pull/240) if still open.
- Run `boilerplate-update` after #748 for `standard.mk` validate fix.

## Test plan

- [ ] `renovate.json` validates against upstream boilerplate extends
- [ ] Dependency Dashboard updates after Konflux rescan
- [ ] No dependency on `MitaliBhalla/boilerplate` fork branch

## Related

- Reverts pilot portion of #285 (renovate.json only)
- openshift/boilerplate#748
- [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)

Made with [Cursor](https://cursor.com)

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to reference an alternate upstream source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->