### PR TITLE
fix: use unique Job names for OLM cleanup to avoid immutable field errors

### DIFF
--- a/deploy_pko/.test-fixtures/config-with-proxy/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/config-with-proxy/Cleanup-OLM-Job.yaml
@@ -1,13 +1,5 @@
 ---
 # This Job cleans up old OLM resources after migrating to PKO
-# IMPORTANT: Review and customize this template before deploying!
-# 
-# Things to customize:
-# 1. Adjust the namespace if needed
-# 2. Modify resource filters (CSV names, labels, etc.)
-# 3. Review RBAC permissions
-# 4. Update the cleanup logic for your specific operator
-#
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,7 +18,6 @@ metadata:
     package-operator.run/phase: cleanup-rbac
     package-operator.run/collision-protection: IfNoController
 rules:
-  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
   - apiGroups:
       - operators.coreos.com
     resources:
@@ -58,12 +49,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-62a0043f
   namespace: openshift-ocm-agent-operator
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  ttlSecondsAfterFinished: 172800
   template:
     metadata:
       annotations:
@@ -83,15 +74,7 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              # CUSTOMIZE: Update the label selector for your operator
-              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
               oc -n openshift-ocm-agent-operator delete csv -l "operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator" || true
-              
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -1,13 +1,5 @@
 ---
 # This Job cleans up old OLM resources after migrating to PKO
-# IMPORTANT: Review and customize this template before deploying!
-# 
-# Things to customize:
-# 1. Adjust the namespace if needed
-# 2. Modify resource filters (CSV names, labels, etc.)
-# 3. Review RBAC permissions
-# 4. Update the cleanup logic for your specific operator
-#
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,7 +18,6 @@ metadata:
     package-operator.run/phase: cleanup-rbac
     package-operator.run/collision-protection: IfNoController
 rules:
-  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
   - apiGroups:
       - operators.coreos.com
     resources:
@@ -58,12 +49,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-{{ .config.image | sha256sum | trunc 8 }}
   namespace: openshift-ocm-agent-operator
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  ttlSecondsAfterFinished: 172800
   template:
     metadata:
       annotations:
@@ -83,15 +74,7 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              # CUSTOMIZE: Update the label selector for your operator
-              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
               oc -n openshift-ocm-agent-operator delete csv -l "operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator" || true
-              
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
### What this PR does / why we need it?

The olm-cleanup Job uses a static name, which causes PKO revision rollouts to fail with "spec.template: field is immutable" when attempting to update the existing Job in-place. This has blocked 7 consecutive revisions from deploying.

Convert the file to a Go template and include a hash of the config image in the Job name so each revision creates a new Job. Add ttlSecondsAfterFinished to auto-clean old Jobs after 48 hours.

```
  ⎿  === ocm-agent-operator-847784f9f ===
     Phase "cleanup-deploy", Job openshift-ocm-agent-operator/olm-cleanup: Job.batch "olm-cleanup" is invalid: spec.template: Invalid value: {"labels":{"batch.kubernetes.i
     o/controller-uid":"93e5699c-11da-4
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup jobs now get a unique name based on the image, reducing naming conflicts.
  * Finished cleanup jobs are automatically removed after 2 days.
* **Chores**
  * Simplified the cleanup job template by removing extra guidance text and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->