### PR TITLE
ROSAENG-61055 add healthz probe

### DIFF
--- a/deploy_pko/.test-fixtures/config-with-proxy/Deployment-ocm-agent-operator.yaml
+++ b/deploy_pko/.test-fixtures/config-with-proxy/Deployment-ocm-agent-operator.yaml
@@ -37,12 +37,24 @@ spec:
             memory: 40Mi
             cpu: 1m
           limits:
-            memory: 64Mi
-            cpu: 10m
+            memory: 200Mi
+            cpu: 50m
         command:
         - ocm-agent-operator
         imagePullPolicy: Always
         terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         env:
         - name: WATCH_NAMESPACE
           value: openshift-ocm-agent-operator

--- a/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-ocm-agent-operator.yaml.gotmpl
@@ -37,12 +37,24 @@ spec:
             memory: 40Mi
             cpu: 1m
           limits:
-            memory: 64Mi
-            cpu: 10m
+            memory: 200Mi
+            cpu: 50m
         command:
         - ocm-agent-operator
         imagePullPolicy: Always
         terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         env:
         - name: WATCH_NAMESPACE
           value: openshift-ocm-agent-operator


### PR DESCRIPTION
### What type of PR is this?
Added healthz probe and bumped resource limits


### What this PR does / why we need it?
[ROSAENG-61055](https://redhat.atlassian.net/browse/ROSAENG-61055)
### Which Jira/Github issue(s) this PR fixes?
[ROSAENG-61055](https://redhat.atlassian.net/browse/ROSAENG-61055)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



[ROSAENG-61055]: https://redhat.atlassian.net/browse/ROSAENG-61055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61055]: https://redhat.atlassian.net/browse/ROSAENG-61055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased container CPU/memory resource requests to improve stability under load.
  * Added liveness and readiness HTTP health checks (port 8081) to detect startup and failure conditions more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->