### PR TITLE
fix: use cached client for handler to reduce audit log volume

### DIFF
--- a/controllers/ocmagent/ocmagent_controller.go
+++ b/controllers/ocmagent/ocmagent_controller.go
@@ -125,17 +125,12 @@ func (r *OcmAgentReconciler) Reconcile(ctx context.Context, request reconcile.Re
 		}
 	}
 
-	// Periodically reconcile to check for pull-secret changes
-	// Since we can't watch openshift-config/pull-secret (due to RBAC/cache issues),
-	// we reconcile every 5 minutes to detect changes
+	// Periodically reconcile to detect pull-secret or proxy config drift
 	return reconcile.Result{RequeueAfter: ctrlconst.SyncPeriodDefault}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *OcmAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Note: We use periodic reconciliation instead of watching pull-secret
-	// due to RBAC/cache issues with openshift-config namespace
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ocmagentv1alpha1.OcmAgent{}).
 		Owns(&netv1.NetworkPolicy{}).

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/fields"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
@@ -150,12 +151,16 @@ func main() {
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Secret{}: {
 					Namespaces: map[string]cache.Config{
-						"openshift-config": {},
+						"openshift-config": {
+							FieldSelector: fields.OneTermEqualSelector("metadata.name", "pull-secret"),
+						},
 					},
 				},
 				&corev1.ConfigMap{}: {
 					Namespaces: map[string]cache.Config{
-						"openshift-monitoring": {},
+						"openshift-monitoring": {
+							FieldSelector: fields.OneTermEqualSelector("metadata.name", "ocm-agent"),
+						},
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -146,6 +147,18 @@ func main() {
 			DefaultNamespaces: map[string]cache.Config{
 				operatorNS: {},
 			},
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						"openshift-config": {},
+					},
+				},
+				&corev1.ConfigMap{}: {
+					Namespaces: map[string]cache.Config{
+						"openshift-monitoring": {},
+					},
+				},
+			},
 		},
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -162,17 +175,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create a separate client for the OAH Builder
-	kubeConfig := ctrl.GetConfigOrDie()
-	handlerClient, err := client.New(kubeConfig, client.Options{Scheme: mgr.GetScheme()})
-	if err != nil {
-		os.Exit(1)
-	}
-
 	if err = (&ocmagent.OcmAgentReconciler{
 		Client:                 mgr.GetClient(),
 		Scheme:                 mgr.GetScheme(),
-		OCMAgentHandlerBuilder: ocmagenthandler.NewBuilder(handlerClient),
+		OCMAgentHandlerBuilder: ocmagenthandler.NewBuilder(mgr.GetClient()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OcmAgent")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- Switch the handler from an uncached `client.New()` to the manager's cached `mgr.GetClient()`, eliminating ~10+ direct API server GET calls per reconciliation cycle (every 5 minutes per cluster)
- Expand the cache configuration with `ByObject` entries to cover cross-namespace resources the handler needs: Secrets in `openshift-config` (pull-secret) and ConfigMaps in `openshift-monitoring` (CAMO ConfigMap)
- Cluster-scoped resources (Proxy, ClusterVersion) are already cacheable by default since `DefaultNamespaces` only restricts namespaced resources

## Context

Investigation of [HCMSEC-3645](https://redhat.atlassian.net/browse/HCMSEC-3645) (Splunk ingestion spike in `osdsecuritylogs`) identified `openshift-ocm-agent-operator` as a contributor. The handler was created with a separate uncached client because the manager's cache was namespace-scoped to the operator namespace and couldn't serve cross-namespace reads. Every reconciliation cycle made direct API calls that generated audit log entries flowing to Splunk. Across thousands of clusters, this adds up significantly.

Controller-runtime v0.23.3 supports `ByObject` cache configuration with per-object namespace overrides, which lets us expand the cache to cover the specific cross-namespace resources without watching entire namespaces.

## What changes

| Before | After |
|--------|-------|
| Handler uses `client.New()` (uncached) | Handler uses `mgr.GetClient()` (cached) |
| Every GET hits API server → audit log | GETs served from informer cache → no audit entry |
| Cache only watches operator namespace | Cache also watches Secrets in `openshift-config` and ConfigMaps in `openshift-monitoring` |

Write operations (Create/Update/Delete) still hit the API server as expected — only read operations benefit from caching.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all unit tests pass (no handler test changes needed since tests mock the `client.Client` interface, which is the same regardless of cached/uncached backing)
- [ ] Deploy to a staging cluster and verify operator reconciles correctly
- [ ] Verify pull-secret changes in `openshift-config` are still detected (cache watch delivers update events)
- [ ] Monitor Splunk audit log volume for reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HCMSEC-3645]: https://redhat.atlassian.net/browse/HCMSEC-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of configuration drift during periodic reconciliation, including pull-secret and proxy settings.

- **Performance & Reliability**
  - Refined controller resource caching for relevant Secrets and ConfigMaps.
  - Streamlined Kubernetes client usage to improve consistency during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->